### PR TITLE
Implement export interfaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'error',
         'import/prefer-default-export': 'off',
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.ts"]}]
+        'import/no-extraneous-dependencies': ['error', {'devDependencies': ['**/*.test.ts']}]
     },
     settings: {
         'import/resolver': {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
         '@typescript-eslint/no-useless-constructor': 'error',
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'error',
-        'import/prefer-default-export': 'off'
+        'import/prefer-default-export': 'off',
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.ts"]}]
     },
     settings: {
         'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
     "fhir-works-on-aws-interface": "^1.0.0",
+    "lodash": "^4.17.20",
     "mime-types": "^2.1.26",
     "promise.allsettled": "^1.0.2",
     "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.1",
+    "@types/lodash": "^4.14.161",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^12",
     "@types/promise.allsettled": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "prepublish": "tsc"
   },
   "dependencies": {
-    "fhir-works-on-aws-interface": "^1.0.0",
     "@elastic/elasticsearch": "7",
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
+    "fhir-works-on-aws-interface": "^1.0.0",
     "mime-types": "^2.1.26",
     "promise.allsettled": "^1.0.2",
     "uuid": "^3.4.0"
@@ -53,6 +53,7 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-prettier": "^3.1.2",
     "jest": "^25.1.0",
+    "jest-each": "^26.4.2",
     "jest-mock-extended": "^1.0.8",
     "prettier": "^1.19.1",
     "sinon": "^9.0.2",

--- a/src/dataServices/dynamoDb.ts
+++ b/src/dataServices/dynamoDb.ts
@@ -10,3 +10,7 @@ export const DynamoDb = new AWS.DynamoDB();
 export const DynamoDBConverter = AWS.DynamoDB.Converter;
 
 export const RESOURCE_TABLE = process.env.RESOURCE_TABLE || '';
+
+export const EXPORT_REQUEST_TABLE = process.env.EXPORT_REQUEST_TABLE || '';
+
+export const EXPORT_REQUEST_TABLE_JOB_STATUS_INDEX = process.env.EXPORT_REQUEST_TABLE_JOB_STATUS_INDEX || '';

--- a/src/dataServices/dynamoDbDataService.test.ts
+++ b/src/dataServices/dynamoDbDataService.test.ts
@@ -9,22 +9,33 @@ import AWSMock from 'aws-sdk-mock';
 import { QueryInput } from 'aws-sdk/clients/dynamodb';
 import * as AWS from 'aws-sdk';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { BundleResponse, BatchReadWriteResponse } from 'fhir-works-on-aws-interface';
+import {
+    BundleResponse,
+    BatchReadWriteResponse,
+    InitiateExportRequest,
+    ResourceNotFoundError,
+} from 'fhir-works-on-aws-interface';
+import { TooManyConcurrentExportRequestsError } from 'fhir-works-on-aws-interface/lib/errors/TooManyConcurrentExportRequestsError';
+import { UnauthorizedAccessError } from 'fhir-works-on-aws-interface/lib/errors/UnauthorizedAccessError';
+import each from 'jest-each';
 import { utcTimeRegExp } from '../../testUtilities/regExpressions';
 import { DynamoDbBundleService } from './dynamoDbBundleService';
 import { DynamoDbDataService } from './dynamoDbDataService';
 import { DynamoDBConverter } from './dynamoDb';
+import DynamoDbParamBuilder from './dynamoDbParamBuilder';
 
 AWSMock.setSDKInstance(AWS);
 
 // eslint-disable-next-line import/order
 import sinon = require('sinon');
 
+beforeEach(() => {
+    expect.hasAssertions();
+});
+afterEach(() => {
+    AWSMock.restore();
+});
 describe('updateResource', () => {
-    afterEach(() => {
-        AWSMock.restore();
-    });
-
     test('Successfully update resource', async () => {
         // BUILD
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
@@ -85,4 +96,202 @@ describe('updateResource', () => {
         expect(serviceResponse.message).toEqual('Resource updated');
         expect(serviceResponse.resource).toMatchObject(expectedResource);
     });
+});
+
+describe('initiateExport', () => {
+    const initiateExportRequest: InitiateExportRequest = {
+        requesterUserId: 'userId-1',
+        exportType: 'system',
+        transactionTime: '2020-09-01T12:00:00Z',
+        outputFormat: 'ndjson',
+        since: '2020-08-01T12:00:00Z',
+        type: 'Patient',
+        groupId: '1',
+    };
+
+    test('Successful initiate export request', async () => {
+        // BUILD
+        // Return an export request that is in-progress
+        AWSMock.mock('DynamoDB', 'query', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                // requesterUserId does not equal requesterUserId from initiateExportRequest therefore we are below throttle limit
+                Items: [DynamoDBConverter.marshall({ requesterUserId: 'userId-2', jobStatus: 'in-progress' })],
+            });
+        });
+        AWSMock.mock('DynamoDB', 'putItem', (params: QueryInput, callback: Function) => {
+            // Successfully update export-request table with request
+            callback(null, {});
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        // OPERATE
+        const jobId = await dynamoDbDataService.initiateExport(initiateExportRequest);
+
+        // CHECK
+        expect(jobId).not.toBeUndefined();
+    });
+
+    test('throttle limit exceeds MAXIMUM_CONCURRENT_REQUEST_PER_USER because user already has an in-progress request', async () => {
+        // BUILD
+        // Return an export request that is in-progress
+        AWSMock.mock('DynamoDB', 'query', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Items: [DynamoDBConverter.marshall({ requesterUserId: 'userId-1', jobStatus: 'in-progress' })],
+            });
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        // OPERATE
+        try {
+            await dynamoDbDataService.initiateExport(initiateExportRequest);
+        } catch (e) {
+            // CHECK
+            expect(e).toMatchObject(new TooManyConcurrentExportRequestsError());
+        }
+    });
+
+    test('throttle limit exceeded MAXIMUM_SYSTEM_LEVEL_CONCURRENT_REQUESTS because system already has two in-progress request', async () => {
+        // BUILD
+        // Return two export requests that are in-progress
+        AWSMock.mock('DynamoDB', 'query', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Items: [
+                    DynamoDBConverter.marshall({ requesterUserId: 'userId-2', jobStatus: 'in-progress' }),
+                    DynamoDBConverter.marshall({ requesterUserId: 'userId-3', jobStatus: 'in-progress' }),
+                ],
+            });
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        // OPERATE
+        try {
+            await dynamoDbDataService.initiateExport(initiateExportRequest);
+        } catch (e) {
+            // CHECK
+            expect(e).toMatchObject(new TooManyConcurrentExportRequestsError());
+        }
+    });
+});
+
+describe('cancelExport', () => {
+    test('Successfully cancel job', async () => {
+        // BUILD
+        AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Item: DynamoDBConverter.marshall({ requesterUserId: 'userId-1', jobStatus: 'in-progress' }),
+            });
+        });
+
+        const updateJobSpy = sinon.spy();
+        AWSMock.mock('DynamoDB', 'updateItem', (params: QueryInput, callback: Function) => {
+            updateJobSpy(params);
+            callback(null, {});
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        const jobId = '2a937fe2-8bb1-442b-b9be-434c94f30e15';
+        // OPERATE
+        await dynamoDbDataService.cancelExport(jobId, 'userId-1');
+
+        // CHECK
+        expect(updateJobSpy.getCall(0).args[0]).toMatchObject(
+            DynamoDbParamBuilder.buildUpdateExportRequestJobStatus(jobId, 'canceling'),
+        );
+    });
+});
+
+describe('getExportStatus', () => {
+    test('Successfully get export job status', async () => {
+        // BUILD
+        AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Item: DynamoDBConverter.marshall({
+                    s3PresignedUrls: [],
+                    jobFailedMessage: '',
+                    outputFormat: 'ndjson',
+                    exportType: 'system',
+                    transactionTime: '2020-09-13T17:19:21.475Z',
+                    since: '2020-09-02T05:00:00.000Z',
+                    requesterUserId: 'userId-1',
+                    groupId: '',
+                    jobId: '2a937fe2-8bb1-442b-b9be-434c94f30e15',
+                    jobStatus: 'in-progress',
+                    stepFunctionExecutionArn: '',
+                    type: 'Patient',
+                }),
+            });
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        // OPERATE
+        const exportStatus = await dynamoDbDataService.getExportStatus(
+            '2a937fe2-8bb1-442b-b9be-434c94f30e15',
+            'userId-1',
+        );
+
+        // CHECK
+        expect(exportStatus).toMatchObject({
+            jobStatus: 'in-progress',
+            exportedFileUrls: [],
+            transactionTime: expect.stringMatching(utcTimeRegExp),
+            exportType: 'system',
+            outputFormat: 'ndjson',
+            since: expect.stringMatching(utcTimeRegExp),
+            type: 'Patient',
+            groupId: '',
+            errorArray: [],
+            errorMessage: '',
+        });
+    });
+});
+
+each(['cancelExport', 'getExportStatus']).test(
+    "%s:Request not authorized because requesterUserId does not match job's requesterUserId",
+    async (testMethod: string) => {
+        // BUILD
+        AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Item: DynamoDBConverter.marshall({ requesterUserId: 'userId-1', jobStatus: 'in-progress' }),
+            });
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        try {
+            // OPERATE
+            if (testMethod === 'cancelExport') {
+                await dynamoDbDataService.cancelExport('2a937fe2-8bb1-442b-b9be-434c94f30e15', 'userId-2');
+            } else {
+                await dynamoDbDataService.getExportStatus('2a937fe2-8bb1-442b-b9be-434c94f30e15', 'userId-2');
+            }
+        } catch (e) {
+            expect(e).toMatchObject(new UnauthorizedAccessError());
+        }
+    },
+);
+
+each(['cancelExport', 'getExportStatus']).test('%s:Unable to find job', async (testMethod: string) => {
+    // BUILD
+    AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
+        callback(null, {});
+    });
+
+    const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+    const jobId = '2a937fe2-8bb1-442b-b9be-434c94f30e15';
+    try {
+        // OPERATE
+        if (testMethod === 'cancelExport') {
+            await dynamoDbDataService.cancelExport(jobId, 'userId-2');
+        } else {
+            await dynamoDbDataService.getExportStatus(jobId, 'userId-2');
+        }
+    } catch (e) {
+        expect(e).toMatchObject(new ResourceNotFoundError('$export', jobId));
+    }
 });

--- a/src/dataServices/dynamoDbDataService.test.ts
+++ b/src/dataServices/dynamoDbDataService.test.ts
@@ -142,7 +142,12 @@ describe('initiateExport', () => {
             // BUILD
             // Return an export request that is in-progress
             AWSMock.mock('DynamoDB', 'query', (params: QueryInput, callback: Function) => {
-                if (isEqual(params, DynamoDbParamBuilder.buildQueryExportRequestJobStatus(jobStatus))) {
+                if (
+                    isEqual(
+                        params,
+                        DynamoDbParamBuilder.buildQueryExportRequestJobStatus(jobStatus, 'jobOwnerId, jobStatus'),
+                    )
+                ) {
                     callback(null, {
                         Items: [DynamoDBConverter.marshall({ jobOwnerId: 'userId-1', jobStatus })],
                     });
@@ -166,11 +171,21 @@ describe('initiateExport', () => {
         // BUILD
         // Return two export requests that are in-progress
         AWSMock.mock('DynamoDB', 'query', (params: QueryInput, callback: Function) => {
-            if (isEqual(params, DynamoDbParamBuilder.buildQueryExportRequestJobStatus('in-progress'))) {
+            if (
+                isEqual(
+                    params,
+                    DynamoDbParamBuilder.buildQueryExportRequestJobStatus('in-progress', 'jobOwnerId, jobStatus'),
+                )
+            ) {
                 callback(null, {
                     Items: [DynamoDBConverter.marshall({ jobOwnerId: 'userId-2', jobStatus: 'in-progress' })],
                 });
-            } else if (isEqual(params, DynamoDbParamBuilder.buildQueryExportRequestJobStatus('canceling'))) {
+            } else if (
+                isEqual(
+                    params,
+                    DynamoDbParamBuilder.buildQueryExportRequestJobStatus('canceling', 'jobOwnerId, jobStatus'),
+                )
+            ) {
                 callback(null, {
                     Items: [DynamoDBConverter.marshall({ jobOwnerId: 'userId-3', jobStatus: 'canceling' })],
                 });

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -207,6 +207,10 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
         if (['completed', 'failed'].includes(jobItem.jobStatus)) {
             throw new Error(`Job cannot be canceled because job is already in ${jobItem.jobStatus} state`);
         }
+        // A job in the canceled or canceling state doesn't need to be updated to 'canceling'
+        if (['canceled', 'canceling'].includes(jobItem.jobStatus)) {
+            return;
+        }
 
         const params = DynamoDbParamBuilder.buildUpdateExportRequestJobStatus(jobId, 'canceling');
         await this.dynamoDb.updateItem(params).promise();

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -25,9 +25,9 @@ import {
     GetExportStatusResponse,
     BulkDataAccess,
     ResourceNotFoundError,
+    TooManyConcurrentExportRequestsError,
 } from 'fhir-works-on-aws-interface';
 import { DynamoDB } from 'aws-sdk';
-import { TooManyConcurrentExportRequestsError } from 'fhir-works-on-aws-interface/lib/errors/TooManyConcurrentExportRequestsError';
 import { DynamoDBConverter } from './dynamoDb';
 import DOCUMENT_STATUS from './documentStatus';
 import { DynamoDbBundleService } from './dynamoDbBundleService';

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -28,8 +28,6 @@ import {
 } from 'fhir-works-on-aws-interface';
 import { DynamoDB } from 'aws-sdk';
 import { TooManyConcurrentExportRequestsError } from 'fhir-works-on-aws-interface/lib/errors/TooManyConcurrentExportRequestsError';
-import { UnauthorizedAccessError } from 'fhir-works-on-aws-interface/lib/errors/UnauthorizedAccessError';
-import { GetItemOutput } from 'aws-sdk/clients/dynamodb';
 import { DynamoDBConverter } from './dynamoDb';
 import DOCUMENT_STATUS from './documentStatus';
 import { DynamoDbBundleService } from './dynamoDbBundleService';

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -165,8 +165,8 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
     }
 
     async throttleExportRequestsIfNeeded(requesterUserId: string) {
-        const jobStatuses: ExportJobStatus[] = ['canceling', 'in-progress'];
-        const exportJobItems = await this.getJobsWithExportStatuses(jobStatuses);
+        const jobStatusesToThrottle: ExportJobStatus[] = ['canceling', 'in-progress'];
+        const exportJobItems = await this.getJobsWithExportStatuses(jobStatusesToThrottle);
 
         if (exportJobItems) {
             const numberOfConcurrentUserRequest = exportJobItems.filter(item => {
@@ -183,7 +183,11 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
 
     async getJobsWithExportStatuses(jobStatuses: ExportJobStatus[]): Promise<ItemList> {
         const jobStatusPromises = jobStatuses.map((jobStatus: ExportJobStatus) => {
-            const queryJobStatusParam = DynamoDbParamBuilder.buildQueryExportRequestJobStatus(jobStatus);
+            const projectionExpression = 'jobOwnerId, jobStatus';
+            const queryJobStatusParam = DynamoDbParamBuilder.buildQueryExportRequestJobStatus(
+                jobStatus,
+                projectionExpression,
+            );
             return this.dynamoDb.query(queryJobStatusParam).promise();
         });
 

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -165,11 +165,9 @@ export default class DynamoDbParamBuilder {
     static buildGetExportRequestJob(jobId: string) {
         const params = {
             TableName: EXPORT_REQUEST_TABLE,
-            Key: {
-                jobId: {
-                    S: jobId,
-                },
-            },
+            Key: DynamoDBConverter.marshall({
+                jobId,
+            }),
         };
 
         return params;

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -3,7 +3,13 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { DynamoDBConverter, RESOURCE_TABLE } from './dynamoDb';
+import { ExportJobStatus, InitiateExportRequest } from 'fhir-works-on-aws-interface';
+import {
+    DynamoDBConverter,
+    RESOURCE_TABLE,
+    EXPORT_REQUEST_TABLE,
+    EXPORT_REQUEST_TABLE_JOB_STATUS_INDEX,
+} from './dynamoDb';
 import { DynamoDbUtil, DOCUMENT_STATUS_FIELD, LOCK_END_TS_FIELD } from './dynamoDbUtil';
 import DOCUMENT_STATUS from './documentStatus';
 
@@ -101,5 +107,71 @@ export default class DynamoDbParamBuilder {
             TableName: RESOURCE_TABLE,
             Item: DynamoDBConverter.marshall(newItem),
         };
+    }
+
+    static buildPutCreateExportRequest(
+        jobId: string,
+        initiateExportRequest: InitiateExportRequest,
+        stepFunctionExecutionArn: string,
+    ) {
+        const item = {
+            jobId,
+            requesterUserId: initiateExportRequest.requesterUserId,
+            exportType: initiateExportRequest.exportType,
+            groupId: initiateExportRequest.groupId ?? '',
+            outputFormat: initiateExportRequest.outputFormat ?? 'ndjson',
+            since: initiateExportRequest.since ?? '1800-01-01T00:00:00Z', // Default to a long time ago in the past
+            type: initiateExportRequest.type ?? '',
+            transactionTime: initiateExportRequest.transactionTime,
+            s3PresignedUrls: [],
+            stepFunctionExecutionArn,
+            jobStatus: 'in-progress',
+            jobFailedMessage: '',
+        };
+        return {
+            TableName: EXPORT_REQUEST_TABLE,
+            Item: DynamoDBConverter.marshall(item),
+        };
+    }
+
+    static buildQueryExportRequestJobStatus(jobStatus: ExportJobStatus) {
+        const params = {
+            TableName: EXPORT_REQUEST_TABLE,
+            KeyConditionExpression: 'jobStatus = :hkey',
+            ExpressionAttributeValues: DynamoDBConverter.marshall({
+                ':hkey': jobStatus,
+            }),
+            IndexName: EXPORT_REQUEST_TABLE_JOB_STATUS_INDEX,
+        };
+
+        return params;
+    }
+
+    static buildUpdateExportRequestJobStatus(jobId: string, jobStatus: ExportJobStatus) {
+        const params = {
+            TableName: EXPORT_REQUEST_TABLE,
+            Key: DynamoDBConverter.marshall({
+                jobId,
+            }),
+            UpdateExpression: 'set jobStatus = :newStatus',
+            ExpressionAttributeValues: DynamoDBConverter.marshall({
+                ':newStatus': jobStatus,
+            }),
+        };
+
+        return params;
+    }
+
+    static buildGetExportRequestJob(jobId: string) {
+        const params = {
+            TableName: EXPORT_REQUEST_TABLE,
+            Key: {
+                jobId: {
+                    S: jobId,
+                },
+            },
+        };
+
+        return params;
     }
 }

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -134,7 +134,7 @@ export default class DynamoDbParamBuilder {
         };
     }
 
-    static buildQueryExportRequestJobStatus(jobStatus: ExportJobStatus) {
+    static buildQueryExportRequestJobStatus(jobStatus: ExportJobStatus, projectionExpression?: string) {
         const params = {
             TableName: EXPORT_REQUEST_TABLE,
             KeyConditionExpression: 'jobStatus = :hkey',
@@ -143,6 +143,11 @@ export default class DynamoDbParamBuilder {
             }),
             IndexName: EXPORT_REQUEST_TABLE_JOB_STATUS_INDEX,
         };
+
+        if (projectionExpression) {
+            // @ts-ignore
+            params.ProjectionExpression = projectionExpression;
+        }
 
         return params;
     }

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -116,7 +116,7 @@ export default class DynamoDbParamBuilder {
     ) {
         const item = {
             jobId,
-            requesterUserId: initiateExportRequest.requesterUserId,
+            jobOwnerId: initiateExportRequest.requesterUserId,
             exportType: initiateExportRequest.exportType,
             groupId: initiateExportRequest.groupId ?? '',
             outputFormat: initiateExportRequest.outputFormat ?? 'ndjson',

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,6 +468,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jest/types@^26.3.0":
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
+  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -613,6 +624,13 @@
   integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^25.1.1":
@@ -1313,6 +1331,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2781,6 +2807,17 @@ jest-each@^25.5.0:
     jest-util "^25.5.0"
     pretty-format "^25.5.0"
 
+jest-each@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.4.2.tgz#bb14f7f4304f2bb2e2b81f783f989449b8b6ffae"
+  integrity sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==
+  dependencies:
+    "@jest/types" "^26.3.0"
+    chalk "^4.0.0"
+    jest-get-type "^26.3.0"
+    jest-util "^26.3.0"
+    pretty-format "^26.4.2"
+
 jest-environment-jsdom@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz#dcbe4da2ea997707997040ecf6e2560aec4e9834"
@@ -2809,6 +2846,11 @@ jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-haste-map@^25.5.1:
   version "25.5.1"
@@ -3028,6 +3070,18 @@ jest-util@^25.5.0:
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"
     make-dir "^3.0.0"
+
+jest-util@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.3.0.tgz#a8974b191df30e2bf523ebbfdbaeb8efca535b3e"
+  integrity sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==
+  dependencies:
+    "@jest/types" "^26.3.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    micromatch "^4.0.2"
 
 jest-validate@^25.5.0:
   version "25.5.0"
@@ -3811,6 +3865,16 @@ pretty-format@^25.1.0, pretty-format@^25.5.0:
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
   dependencies:
     "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
+  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
+  dependencies:
+    "@jest/types" "^26.3.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/lodash@^4.14.161":
+  version "4.14.161"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
+  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+
 "@types/mime-types@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
@@ -3322,6 +3327,11 @@ lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lolex@^5.0.0:
   version "5.1.2"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Implement `initiateExport`, `getExportStatus`, and `cancelExport`. For all three methods, write and read data from DDB as necessary. 

For `initiateExport` only implement writing to `DDB`. Invoking stepFunction is a  future SIM task, after the SIM tasks for Glue Export step function is completed.

**Related PR**
https://github.com/awslabs/fhir-works-on-aws-deployment/pull/104

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.