### PR TITLE
feat: change sort key (versionId) from String to Num

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,4 @@ tsconfig.json
 .github
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
+CODEOWNERS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0] - 2020-08-31
+
+### Added
+
+- feat: Assume that the Resource DDB sort key is a number not a String
+  - BREAKING CHANGE: This change will not be successful if sort key is still a String
+
 ## [1.1.0] - 2020-08-31
 
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @awslabs/fhir-works

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-persistence-ddb",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "FHIR Works on AWS persistence DynamoDB implementation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,11 +28,11 @@
     "prepublish": "tsc"
   },
   "dependencies": {
-    "fhir-works-on-aws-interface": "^1.0.0",
     "@elastic/elasticsearch": "7",
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
+    "fhir-works-on-aws-interface": "^1.0.0",
     "mime-types": "^2.1.26",
     "promise.allsettled": "^1.0.2",
     "uuid": "^3.4.0"

--- a/src/dataServices/dynamoDbBundleServiceHelper.test.ts
+++ b/src/dataServices/dynamoDbBundleServiceHelper.test.ts
@@ -80,7 +80,7 @@ describe('generateStagingRequests', () => {
     });
 
     test('CRUD', () => {
-        let idToVersionId: Record<string, string> = {};
+        let idToVersionId: Record<string, number> = {};
         idToVersionId = {
             ...GenerateStagingRequestsFactory.getRead().idToVersionId,
             ...GenerateStagingRequestsFactory.getUpdate().idToVersionId,

--- a/src/dataServices/dynamoDbDataService.test.ts
+++ b/src/dataServices/dynamoDbDataService.test.ts
@@ -6,21 +6,162 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import AWSMock from 'aws-sdk-mock';
 
-import { QueryInput } from 'aws-sdk/clients/dynamodb';
+import { GetItemInput, PutItemInput, QueryInput, UpdateItemInput } from 'aws-sdk/clients/dynamodb';
 import * as AWS from 'aws-sdk';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { BundleResponse, BatchReadWriteResponse } from 'fhir-works-on-aws-interface';
+import { BundleResponse, BatchReadWriteResponse, ResourceVersionNotFoundError } from 'fhir-works-on-aws-interface';
 import { utcTimeRegExp } from '../../testUtilities/regExpressions';
 import { DynamoDbBundleService } from './dynamoDbBundleService';
 import { DynamoDbDataService } from './dynamoDbDataService';
 import { DynamoDBConverter } from './dynamoDb';
+import DynamoDbHelper from './dynamoDbHelper';
 
 AWSMock.setSDKInstance(AWS);
 
 // eslint-disable-next-line import/order
 import sinon = require('sinon');
 
-describe('updateResource', () => {
+describe('CREATE', () => {
+    afterEach(() => {
+        AWSMock.restore();
+    });
+    test('SUCCESS: Create Resource', async () => {
+        // BUILD
+        const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
+        const resourceType = 'Patient';
+        const resource = {
+            id,
+            resourceType,
+            name: [
+                {
+                    family: 'Jameson',
+                    given: ['Matt'],
+                },
+            ],
+        };
+
+        // READ items (Success)
+        AWSMock.mock('DynamoDB', 'putItem', (params: PutItemInput, callback: Function) => {
+            callback(null, 'success');
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        // OPERATE
+        const serviceResponse = await dynamoDbDataService.createResource({ resource, resourceType, id });
+
+        // CHECK
+        const expectedResource: any = { ...resource };
+        expectedResource.meta = {
+            versionId: '1',
+            lastUpdated: expect.stringMatching(utcTimeRegExp),
+        };
+
+        expect(serviceResponse.success).toEqual(true);
+        expect(serviceResponse.message).toEqual('Resource created');
+        expect(serviceResponse.resource).toStrictEqual(expectedResource);
+    });
+});
+
+describe('READ', () => {
+    // beforeEach(() => {
+    //     // Ensures that for each test, we test the assertions in the catch block
+    //     expect.hasAssertions();
+    // });
+    afterEach(() => {
+        AWSMock.restore();
+    });
+    test('SUCCESS: Get Resource', async () => {
+        // BUILD
+        const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
+        const resourceType = 'Patient';
+        const resource = {
+            id,
+            resourceType,
+            name: [
+                {
+                    family: 'Jameson',
+                    given: ['Matt'],
+                },
+            ],
+            meta: { versionId: '1', lastUpdated: new Date().toISOString() },
+        };
+
+        sinon
+            .stub(DynamoDbHelper.prototype, 'getMostRecentValidResource')
+            .returns(Promise.resolve({ message: 'Resource found', resource }));
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        // OPERATE
+        const serviceResponse = await dynamoDbDataService.readResource({ resourceType, id });
+
+        // CHECK
+        expect(serviceResponse.message).toEqual('Resource found');
+        expect(serviceResponse.resource).toStrictEqual(resource);
+    });
+    test('SUCCESS: Get Versioned Resource', async () => {
+        // BUILD
+        const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
+        const vid = '5';
+        const resourceType = 'Patient';
+        const resource = {
+            id,
+            vid: parseInt(vid, 10),
+            resourceType,
+            documentStatus: 'shouldberemoved',
+            name: [
+                {
+                    family: 'Jameson',
+                    given: ['Matt'],
+                },
+            ],
+            meta: { versionId: vid, lastUpdated: new Date().toISOString() },
+        };
+
+        // READ items (Success)
+        AWSMock.mock('DynamoDB', 'getItem', (params: GetItemInput, callback: Function) => {
+            callback(null, {
+                Item: DynamoDBConverter.marshall(resource),
+            });
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB({ apiVersion: '2012-08-10' }));
+
+        // OPERATE
+        const serviceResponse = await dynamoDbDataService.vReadResource({ resourceType, id, vid });
+
+        // CHECK
+        expect(serviceResponse.message).toEqual('Resource found');
+        const expectedResource = { ...resource };
+        delete expectedResource.vid;
+        delete expectedResource.documentStatus;
+        expect(serviceResponse.resource).toStrictEqual(expectedResource);
+    });
+
+    test('ERROR: Get Versioned Resource', async () => {
+        // BUILD
+        const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
+        const vid = '5';
+        const resourceType = 'Patient';
+
+        // READ items (Success)
+        AWSMock.mock('DynamoDB', 'getItem', (params: GetItemInput, callback: Function) => {
+            callback(null, { Item: undefined });
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+        try {
+            // OPERATE
+            await dynamoDbDataService.vReadResource({ resourceType, id, vid });
+        } catch (e) {
+            // CHECK
+            expect(e).toMatchObject(new ResourceVersionNotFoundError(resourceType, id, vid));
+        }
+    });
+});
+
+describe('UPDATE', () => {
     afterEach(() => {
         AWSMock.restore();
     });
@@ -30,7 +171,7 @@ describe('updateResource', () => {
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
         const resource = {
             id,
-            vid: '1',
+            vid: 1,
             resourceType: 'Patient',
             name: [
                 {
@@ -38,7 +179,7 @@ describe('updateResource', () => {
                     given: ['Matt'],
                 },
             ],
-            meta: { versionId: '1', lastUpdate: new Date().toUTCString() },
+            meta: { versionId: '1', lastUpdated: new Date().toISOString() },
         };
 
         // READ items (Success)
@@ -48,10 +189,10 @@ describe('updateResource', () => {
             });
         });
 
-        const vid = '2';
+        const vid = 2;
         const batchReadWriteResponse: BatchReadWriteResponse = {
             id,
-            vid,
+            vid: vid.toString(),
             resourceType: 'Patient',
             operation: 'update',
             resource: {},
@@ -83,6 +224,56 @@ describe('updateResource', () => {
 
         expect(serviceResponse.success).toEqual(true);
         expect(serviceResponse.message).toEqual('Resource updated');
-        expect(serviceResponse.resource).toMatchObject(expectedResource);
+        expect(serviceResponse.resource).toStrictEqual(expectedResource);
+    });
+});
+
+describe('DELETE', () => {
+    afterEach(() => {
+        AWSMock.restore();
+    });
+
+    test('Successfully delete resource', async () => {
+        // BUILD
+        const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
+        const resourceType = 'Patient';
+        const vid = 1;
+        const resource = {
+            id,
+            vid,
+            resourceType,
+            name: [
+                {
+                    family: 'Jameson',
+                    given: ['Matt'],
+                },
+            ],
+            meta: { versionId: vid.toString(), lastUpdated: new Date().toISOString() },
+        };
+
+        // READ items (Success)
+        AWSMock.mock('DynamoDB', 'query', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Items: [DynamoDBConverter.marshall(resource)],
+            });
+        });
+
+        // UPDATE (delete) item (Success)
+        AWSMock.mock('DynamoDB', 'updateItem', (params: UpdateItemInput, callback: Function) => {
+            callback(null, {
+                Items: [DynamoDBConverter.marshall(resource)],
+            });
+        });
+
+        const dynamoDbDataService = new DynamoDbDataService(new AWS.DynamoDB());
+
+        // OPERATE
+        const serviceResponse = await dynamoDbDataService.deleteResource({ resourceType, id });
+
+        // CHECK
+        expect(serviceResponse.success).toEqual(true);
+        expect(serviceResponse.message).toEqual(
+            `Successfully deleted ResourceType: ${resourceType}, Id: ${id}, VersionId: ${vid}`,
+        );
     });
 });

--- a/src/dataServices/dynamoDbHelper.ts
+++ b/src/dataServices/dynamoDbHelper.ts
@@ -41,7 +41,9 @@ export default class DynamoDbHelper {
         const params = DynamoDbParamBuilder.buildGetResourcesQueryParam(id, 2);
         let item = null;
         const result = await this.dynamoDb.query(params).promise();
-        const items = result.Items ? result.Items.map(ddbJsonItem => DynamoDBConverter.unmarshall(ddbJsonItem)) : [];
+        const items = result.Items
+            ? result.Items.map((ddbJsonItem: any) => DynamoDBConverter.unmarshall(ddbJsonItem))
+            : [];
         if (items.length === 0) {
             throw new ResourceNotFoundError(resourceType, id);
         }

--- a/src/dataServices/dynamoDbParamBuilder.test.ts
+++ b/src/dataServices/dynamoDbParamBuilder.test.ts
@@ -10,7 +10,7 @@ import { timeFromEpochInMsRegExp } from '../../testUtilities/regExpressions';
 describe('buildUpdateDocumentStatusParam', () => {
     test('Update status correctly when there is a requirement for what the old status needs to be', () => {
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
-        const vid = '1';
+        const vid = 1;
 
         // Check that the old status is AVAILABLE before changing it to LOCK
         const actualParam = DynamoDbParamBuilder.buildUpdateDocumentStatusParam(
@@ -28,7 +28,7 @@ describe('buildUpdateDocumentStatusParam', () => {
                         S: id,
                     },
                     vid: {
-                        S: vid,
+                        N: vid.toString(),
                     },
                 },
                 UpdateExpression: 'set documentStatus = :newStatus, lockEndTs = :futureEndTs',
@@ -67,7 +67,7 @@ describe('buildUpdateDocumentStatusParam', () => {
         expect(actualParam).toEqual(expectedParam);
     });
 
-    const getExpectedParamForUpdateWithoutOldStatus = (documentStatus: DOCUMENT_STATUS, id: string, vid: string) => {
+    const getExpectedParamForUpdateWithoutOldStatus = (documentStatus: DOCUMENT_STATUS, id: string, vid: number) => {
         return {
             Update: {
                 TableName: '',
@@ -76,7 +76,7 @@ describe('buildUpdateDocumentStatusParam', () => {
                         S: id,
                     },
                     vid: {
-                        S: vid,
+                        N: vid.toString(),
                     },
                 },
                 UpdateExpression: 'set documentStatus = :newStatus, lockEndTs = :futureEndTs',
@@ -95,7 +95,7 @@ describe('buildUpdateDocumentStatusParam', () => {
 
     test('When a document is being locked, lockEndTs should have a timestamp that expires in the future', () => {
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
-        const vid = '1';
+        const vid = 1;
         const actualParam = DynamoDbParamBuilder.buildUpdateDocumentStatusParam(null, DOCUMENT_STATUS.LOCKED, id, vid);
 
         const futureTs = Number(actualParam.Update.ExpressionAttributeValues[':futureEndTs'].N);
@@ -112,7 +112,7 @@ describe('buildUpdateDocumentStatusParam', () => {
 
     test('Update status correctly when there is NO requirement for what the old status needs to be', () => {
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
-        const vid = '1';
+        const vid = 1;
         // Check the status to be AVAILABLE no matter what the previous status was
         const actualParam = DynamoDbParamBuilder.buildUpdateDocumentStatusParam(
             null,
@@ -135,7 +135,7 @@ describe('buildUpdateDocumentStatusParam', () => {
 describe('buildPutItemParam', () => {
     test('check that param has the fields documentStatus and lockEndTs', () => {
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
-        const vid = '1';
+        const vid = 1;
         const item = {
             resourceType: 'Patient',
             id,
@@ -148,7 +148,7 @@ describe('buildPutItemParam', () => {
             gender: 'male',
             meta: {
                 lastUpdated: '2020-03-26T15:46:55.848Z',
-                versionId: vid,
+                versionId: vid.toString(),
             },
         };
         const actualParams = DynamoDbParamBuilder.buildPutAvailableItemParam(item, id, vid);
@@ -162,7 +162,7 @@ describe('buildPutItemParam', () => {
                     S: id,
                 },
                 vid: {
-                    S: vid,
+                    N: vid.toString(),
                 },
                 name: {
                     L: [

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -14,7 +14,7 @@ export default class DynamoDbParamBuilder {
         oldStatus: DOCUMENT_STATUS | null,
         newStatus: DOCUMENT_STATUS,
         id: string,
-        vid: string,
+        vid: number,
     ) {
         const currentTs = Date.now();
         let futureEndTs = currentTs;
@@ -71,7 +71,7 @@ export default class DynamoDbParamBuilder {
         return params;
     }
 
-    static buildDeleteParam(id: string, vid: string) {
+    static buildDeleteParam(id: string, vid: number) {
         const params: any = {
             Delete: {
                 TableName: RESOURCE_TABLE,
@@ -85,7 +85,7 @@ export default class DynamoDbParamBuilder {
         return params;
     }
 
-    static buildGetItemParam(id: string, vid: string) {
+    static buildGetItemParam(id: string, vid: number) {
         return {
             TableName: RESOURCE_TABLE,
             Key: DynamoDBConverter.marshall({
@@ -95,7 +95,7 @@ export default class DynamoDbParamBuilder {
         };
     }
 
-    static buildPutAvailableItemParam(item: any, id: string, vid: string) {
+    static buildPutAvailableItemParam(item: any, id: string, vid: number) {
         const newItem = DynamoDbUtil.prepItemForDdbInsert(item, id, vid, DOCUMENT_STATUS.AVAILABLE);
         return {
             TableName: RESOURCE_TABLE,

--- a/src/dataServices/dynamoDbUtil.test.ts
+++ b/src/dataServices/dynamoDbUtil.test.ts
@@ -10,7 +10,7 @@ import { timeFromEpochInMsRegExp, utcTimeRegExp } from '../../testUtilities/regE
 
 describe('cleanItem', () => {
     const id = 'ee3928b9-8699-4970-ba49-8f41bd122f46';
-    const vid = '2';
+    const vid = 2;
 
     test('Remove documentStatus field and format id correctly', () => {
         const item: any = {
@@ -49,7 +49,7 @@ describe('cleanItem', () => {
 
 describe('prepItemForDdbInsert', () => {
     const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
-    const vid = '1';
+    const vid = 1;
     const resource = {
         resourceType: 'Patient',
         id,
@@ -62,7 +62,7 @@ describe('prepItemForDdbInsert', () => {
         gender: 'male',
         meta: {
             lastUpdated: '2020-03-26T15:46:55.848Z',
-            versionId: vid,
+            versionId: vid.toString(),
         },
     };
 
@@ -72,7 +72,7 @@ describe('prepItemForDdbInsert', () => {
         expectedItem.id = id;
         expectedItem.vid = vid;
         expectedItem.meta = {
-            versionId: vid,
+            versionId: vid.toString(),
             lastUpdated: expect.stringMatching(utcTimeRegExp),
         };
 
@@ -88,7 +88,7 @@ describe('prepItemForDdbInsert', () => {
         const actualItem = DynamoDbUtil.prepItemForDdbInsert(updatedResource, id, vid, DOCUMENT_STATUS.PENDING);
 
         // CHECK
-        updatedResource.meta.versionId = vid;
+        updatedResource.meta.versionId = vid.toString();
         checkExpectedItemMatchActualItem(actualItem, updatedResource);
     });
 

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -26,15 +26,15 @@ export class DynamoDbUtil {
         return cleanedItem;
     }
 
-    static prepItemForDdbInsert(resource: any, id: string, vid: string, documentStatus: DOCUMENT_STATUS) {
+    static prepItemForDdbInsert(resource: any, id: string, vid: number, documentStatus: DOCUMENT_STATUS) {
         const item = clone(resource);
         item.id = id;
         item.vid = vid;
         if (vid && !item.meta) {
-            item.meta = generateMeta(vid);
+            item.meta = generateMeta(vid.toString());
         }
         if (vid && item.meta && !item.meta.versionId) {
-            const generatedMeta = generateMeta(vid);
+            const generatedMeta = generateMeta(vid.toString());
             item.meta = { ...item.meta, ...generatedMeta };
         }
         item[DOCUMENT_STATUS_FIELD] = documentStatus;

--- a/src/ddbToEs/ddbToEsHelper.ts
+++ b/src/ddbToEs/ddbToEsHelper.ts
@@ -68,7 +68,7 @@ export default class DdbToEsHelper {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    private generateFullId(id: string, vid: string) {
+    private generateFullId(id: string, vid: number) {
         return `${id}_${vid}`;
     }
 

--- a/testUtilities/GenerateRollbackRequestsFactory.ts
+++ b/testUtilities/GenerateRollbackRequestsFactory.ts
@@ -54,11 +54,11 @@ export default class GenerateRollbackRequestsFactory {
 
     static buildExpectedBundleEntryResult(bundleEntryResponse: BatchReadWriteResponse) {
         const { id, vid, resourceType, operation } = bundleEntryResponse;
-
+        // const vidNum = parseInt(vid, 10);
         let expectedResult: any = {};
         if (operation === 'create' || operation === 'update') {
             expectedResult = {
-                transactionRequests: [DynamoDbParamBuilder.buildDeleteParam(id, vid)],
+                transactionRequests: [DynamoDbParamBuilder.buildDeleteParam(id, parseInt(vid, 10))],
                 itemsToRemoveFromLock: [
                     {
                         id,

--- a/testUtilities/GenerateRollbackRequestsFactory.ts
+++ b/testUtilities/GenerateRollbackRequestsFactory.ts
@@ -54,7 +54,6 @@ export default class GenerateRollbackRequestsFactory {
 
     static buildExpectedBundleEntryResult(bundleEntryResponse: BatchReadWriteResponse) {
         const { id, vid, resourceType, operation } = bundleEntryResponse;
-        // const vidNum = parseInt(vid, 10);
         let expectedResult: any = {};
         if (operation === 'create' || operation === 'update') {
             expectedResult = {

--- a/testUtilities/GenerateStagingRequestsFactory.ts
+++ b/testUtilities/GenerateStagingRequestsFactory.ts
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable class-methods-use-this */
-import { BatchReadWriteRequest } from 'fhir-works-on-aws-interface';
+import { BatchReadWriteRequest, BatchReadWriteResponse } from 'fhir-works-on-aws-interface';
 import { DynamoDBConverter } from '../src/dataServices/dynamoDb';
 import { DOCUMENT_STATUS_FIELD } from '../src/dataServices/dynamoDbUtil';
 import DOCUMENT_STATUS from '../src/dataServices/documentStatus';
@@ -44,12 +44,12 @@ export default class GenerateStagingRequestsFactory {
 
         const expectedLock = {
             id: expect.stringMatching(uuidRegExp),
-            vid: '1',
+            vid: 1,
             resourceType: 'Patient',
             operation: 'create',
         };
 
-        const expectedStagingResponse = {
+        const expectedStagingResponse: BatchReadWriteResponse = {
             id: expect.stringMatching(uuidRegExp),
             vid: '1',
             operation: 'create',
@@ -76,7 +76,7 @@ export default class GenerateStagingRequestsFactory {
             id,
         };
 
-        const vid = '1';
+        const vid = 1;
 
         const expectedRequest = {
             Get: {
@@ -86,23 +86,23 @@ export default class GenerateStagingRequestsFactory {
                         S: id,
                     },
                     vid: {
-                        S: vid,
+                        N: vid.toString(),
                     },
                 },
             },
         };
 
         const expectedLock: [] = [];
-        const expectedStagingResponse = {
+        const expectedStagingResponse: BatchReadWriteResponse = {
             id,
-            vid,
+            vid: vid.toString(),
             operation: 'read',
             lastModified: '',
             resource: {},
             resourceType: 'Patient',
         };
 
-        const idToVersionId: Record<string, string> = {};
+        const idToVersionId: Record<string, number> = {};
         idToVersionId[id] = vid;
 
         return {
@@ -134,8 +134,8 @@ export default class GenerateStagingRequestsFactory {
             resource,
             fullUrl: `urn:uuid:${id}`,
         };
-        const vid = '1';
-        const nextVid = '2';
+        const vid = 1;
+        const nextVid = 2;
         const expectedUpdateItem: any = { ...resource };
         expectedUpdateItem[DOCUMENT_STATUS_FIELD] = DOCUMENT_STATUS.PENDING;
         expectedUpdateItem.id = id;
@@ -156,16 +156,16 @@ export default class GenerateStagingRequestsFactory {
             isOriginalUpdateItem: false,
         };
 
-        const expectedStagingResponse = {
+        const expectedStagingResponse: BatchReadWriteResponse = {
             id: expect.stringMatching(uuidRegExp),
-            vid: nextVid,
+            vid: nextVid.toString(),
             operation: 'update',
             resourceType: 'Patient',
             resource: {},
             lastModified: expect.stringMatching(utcTimeRegExp),
         };
 
-        const idToVersionId: Record<string, string> = {};
+        const idToVersionId: Record<string, number> = {};
         idToVersionId[id] = vid;
 
         return {
@@ -187,7 +187,7 @@ export default class GenerateStagingRequestsFactory {
             id,
         };
 
-        const vid = '1';
+        const vid = 1;
         const expectedRequest = DynamoDbParamBuilder.buildUpdateDocumentStatusParam(
             DOCUMENT_STATUS.LOCKED,
             DOCUMENT_STATUS.PENDING_DELETE,
@@ -204,16 +204,16 @@ export default class GenerateStagingRequestsFactory {
 
         const expectedLock: [] = [];
 
-        const expectedStagingResponse = {
+        const expectedStagingResponse: BatchReadWriteResponse = {
             id,
-            vid,
+            vid: vid.toString(),
             operation: 'delete',
             lastModified: expect.stringMatching(utcTimeRegExp),
             resource: {},
             resourceType: 'Patient',
         };
 
-        const idToVersionId: Record<string, string> = {};
+        const idToVersionId: Record<string, number> = {};
         idToVersionId[id] = vid;
 
         return {
@@ -230,5 +230,5 @@ interface RequestResult {
     expectedRequest: any;
     expectedLock: any;
     expectedStagingResponse: any;
-    idToVersionId: Record<string, string>;
+    idToVersionId: Record<string, number>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,6 +2026,7 @@ fb-watchman@^2.0.0:
     bser "2.1.1"
 
 fhir-works-on-aws-interface@^1.0.0:
+  version "1.0.0"
   resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-1.0.0.tgz#7de73929ebab013745582518f7596607c85a4ad0"
   integrity sha512-b+B7D4/Msfzku/efM7dhbqCANEjCEKqUm7YJwEsQVjfmNbyRHWNmk+Mer89POmPnbw0eqryjnvV7C698C/8+rQ==
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,8 +2025,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-"fhir-works-on-aws-interface@file:.yalc/fhir-works-on-aws-interface":
-  version "1.0.0"
+fhir-works-on-aws-interface@^1.0.0:
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-1.0.0.tgz#7de73929ebab013745582518f7596607c85a4ad0"
+  integrity sha512-b+B7D4/Msfzku/efM7dhbqCANEjCEKqUm7YJwEsQVjfmNbyRHWNmk+Mer89POmPnbw0eqryjnvV7C698C/8+rQ==
 
 figures@^3.0.0:
   version "3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,10 +2025,8 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^1.0.0:
+"fhir-works-on-aws-interface@file:.yalc/fhir-works-on-aws-interface":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-1.0.0.tgz#7de73929ebab013745582518f7596607c85a4ad0"
-  integrity sha512-b+B7D4/Msfzku/efM7dhbqCANEjCEKqUm7YJwEsQVjfmNbyRHWNmk+Mer89POmPnbw0eqryjnvV7C698C/8+rQ==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/fhir-works-on-aws-deployment/issues/108

Description of changes:
* Using the versionId as a String sort key, results in incorrect sort when we get versionId > 10
* Make versionId a Num
* Added many more tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.