### PR TITLE
chore: Upgrade fhir-works-on-aws-interface dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.1] - 2020-10-31
+- chore: Upgrade fhir-works-on-aws-interface dependency
+
 ## [2.0.0] - 2020-08-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-persistence-ddb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "FHIR Works on AWS persistence DynamoDB implementation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -32,7 +32,7 @@
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
-    "fhir-works-on-aws-interface": "^1.0.0",
+    "fhir-works-on-aws-interface": "^2.0.0",
     "mime-types": "^2.1.26",
     "promise.allsettled": "^1.0.2",
     "uuid": "^3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,10 +2025,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-1.0.0.tgz#7de73929ebab013745582518f7596607c85a4ad0"
-  integrity sha512-b+B7D4/Msfzku/efM7dhbqCANEjCEKqUm7YJwEsQVjfmNbyRHWNmk+Mer89POmPnbw0eqryjnvV7C698C/8+rQ==
+fhir-works-on-aws-interface@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-2.0.0.tgz#98c04208c32653f9d75743663c036f1d6eae6ffb"
+  integrity sha512-hdjZJaNEoSYXYVEDOtCQW/HxnQhnF2Nu02nzgeNEWdsZN8MiMakmLX/JxnPYmG13/L9J69CpeV1PmZCsT9HG3g==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Description of changes:
Just bumping dependency version. There are no changes on the latest interface related to Persistence

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.