### PR TITLE
feat: Add Auth token to API requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prepublish": "tsc"
   },
   "dependencies": {
+    "aws4-axios": "^1.12.0",
     "axios": "^0.20.0",
     "fhir-works-on-aws-interface": "^1.0.0",
     "mime-types": "^2.1.26"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-persistence-ddb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "FHIR Works on AWS persistence DynamoDB implementation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -30,7 +30,7 @@
   "dependencies": {
     "aws4-axios": "^1.12.0",
     "axios": "^0.20.0",
-    "fhir-works-on-aws-interface": "^1.0.0",
+    "fhir-works-on-aws-interface": "^2.0.0",
     "mime-types": "^2.1.26"
   },
   "devDependencies": {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,0 +1,4 @@
+export default interface Auth {
+    // Hook into axios and intercept requests
+    initialize(): void;
+}

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,5 +1,7 @@
+import { AxiosInstance } from 'axios';
+
 export default interface Auth {
     // Hook into axios and intercept requests to add Auth tokens
     // https://masteringjs.io/tutorials/axios/interceptors
-    initialize(): void;
+    attachInterceptor(axiosInstance: AxiosInstance): void;
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,4 +1,5 @@
 export default interface Auth {
-    // Hook into axios and intercept requests
+    // Hook into axios and intercept requests to add Auth tokens
+    // https://masteringjs.io/tutorials/axios/interceptors
     initialize(): void;
 }

--- a/src/auth/iamAuth.ts
+++ b/src/auth/iamAuth.ts
@@ -1,15 +1,15 @@
-import axios from 'axios';
+import { AxiosInstance } from 'axios';
 import { aws4Interceptor } from 'aws4-axios';
 import Auth from './auth';
 
 const { AWS_REGION } = process.env;
 export default class IamAuth implements Auth {
     // eslint-disable-next-line class-methods-use-this
-    initialize(): void {
+    attachInterceptor(axiosInstance: AxiosInstance) {
         const interceptor = aws4Interceptor({
             region: AWS_REGION,
             service: 'execute-api',
         });
-        axios.interceptors.request.use(interceptor);
+        axiosInstance.interceptors.request.use(interceptor);
     }
 }

--- a/src/auth/iamAuth.ts
+++ b/src/auth/iamAuth.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import { aws4Interceptor } from 'aws4-axios';
+import Auth from './auth';
+
+export default class IamAuth implements Auth {
+    // eslint-disable-next-line class-methods-use-this
+    initialize(): void {
+        // TODO: Grab region value from ENV variable
+        const interceptor = aws4Interceptor({
+            region: 'us-west-2',
+            service: 'execute-api',
+        });
+        axios.interceptors.request.use(interceptor);
+    }
+}

--- a/src/auth/iamAuth.ts
+++ b/src/auth/iamAuth.ts
@@ -2,12 +2,12 @@ import axios from 'axios';
 import { aws4Interceptor } from 'aws4-axios';
 import Auth from './auth';
 
+const { AWS_REGION } = process.env;
 export default class IamAuth implements Auth {
     // eslint-disable-next-line class-methods-use-this
     initialize(): void {
-        // TODO: Grab region value from ENV variable
         const interceptor = aws4Interceptor({
-            region: 'us-west-2',
+            region: AWS_REGION,
             service: 'execute-api',
         });
         axios.interceptors.request.use(interceptor);

--- a/src/dataServices/apiDataService.test.ts
+++ b/src/dataServices/apiDataService.test.ts
@@ -35,8 +35,10 @@ const resource = {
     id: 'f2ddf33c-9344-49cd-991f-8273eb959f92',
 };
 
-const apiDataService = new ApiDataService('http://localhost:4000');
-const mock = new MockAdapter(axios);
+const baseURL = 'http://localhost:4000';
+const axiosInstance = axios.create({ baseURL });
+const apiDataService = new ApiDataService(baseURL, axiosInstance);
+const mock = new MockAdapter(axiosInstance);
 afterEach(() => {
     mock.reset();
 });

--- a/src/dataServices/apiDataService.ts
+++ b/src/dataServices/apiDataService.ts
@@ -12,23 +12,23 @@ import {
     UpdateResourceRequest,
     vReadResourceRequest,
 } from 'fhir-works-on-aws-interface';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import IamAuth from '../auth/iamAuth';
 
 export class ApiDataService implements Persistence {
     updateCreateSupported: boolean = false;
 
-    private INTEGRATION_TRANSFORM_URL: string;
+    private axiosInstance: AxiosInstance;
 
-    constructor(integrationTransformUrl: string) {
-        this.INTEGRATION_TRANSFORM_URL = integrationTransformUrl;
-        new IamAuth().initialize();
+    constructor(integrationTransformUrl: string, axiosInstance: AxiosInstance | undefined = undefined) {
+        const instance = axiosInstance ?? axios.create({ baseURL: integrationTransformUrl });
+        new IamAuth().attachInterceptor(instance);
+        this.axiosInstance = instance;
     }
 
     async createResource(request: CreateResourceRequest): Promise<GenericResponse> {
         try {
-            const url = `${this.INTEGRATION_TRANSFORM_URL}/persistence/${request.resourceType}`;
-            const response = await axios.post(url, request.resource);
+            const response = await this.axiosInstance.post(`/persistence/${request.resourceType}`, request.resource);
             return { message: '', resource: response.data.resource };
         } catch (e) {
             throw this.getError(e);
@@ -37,9 +37,7 @@ export class ApiDataService implements Persistence {
 
     async readResource(request: ReadResourceRequest): Promise<GenericResponse> {
         try {
-            const response = await axios.get(
-                `${this.INTEGRATION_TRANSFORM_URL}/persistence/${request.resourceType}/${request.id}`,
-            );
+            const response = await this.axiosInstance.get(`/persistence/${request.resourceType}/${request.id}`);
             return { message: '', resource: response.data.resource };
         } catch (e) {
             throw this.getError(e, request.resourceType, request.id);
@@ -48,8 +46,8 @@ export class ApiDataService implements Persistence {
 
     async updateResource(request: UpdateResourceRequest): Promise<GenericResponse> {
         try {
-            const response = await axios.put(
-                `${this.INTEGRATION_TRANSFORM_URL}/persistence/${request.resourceType}/${request.id}`,
+            const response = await this.axiosInstance.put(
+                `/persistence/${request.resourceType}/${request.id}`,
                 request.resource,
             );
             return { message: '', resource: response.data.resource };
@@ -60,7 +58,7 @@ export class ApiDataService implements Persistence {
 
     async deleteResource(request: DeleteResourceRequest): Promise<GenericResponse> {
         try {
-            await axios.delete(`${this.INTEGRATION_TRANSFORM_URL}/persistence/${request.resourceType}/${request.id}`);
+            await this.axiosInstance.delete(`/persistence/${request.resourceType}/${request.id}`);
             // Don't need to actually return anything to the router
             return { message: '' };
         } catch (e) {

--- a/src/dataServices/apiDataService.ts
+++ b/src/dataServices/apiDataService.ts
@@ -13,6 +13,13 @@ import {
     vReadResourceRequest,
 } from 'fhir-works-on-aws-interface';
 import axios from 'axios';
+import { aws4Interceptor } from 'aws4-axios';
+// TODO: Grab region value from ENV variable
+const interceptor = aws4Interceptor({
+    region: 'us-west-2',
+    service: 'execute-api',
+});
+axios.interceptors.request.use(interceptor);
 
 export class ApiDataService implements Persistence {
     updateCreateSupported: boolean = false;
@@ -25,7 +32,9 @@ export class ApiDataService implements Persistence {
 
     async createResource(request: CreateResourceRequest): Promise<GenericResponse> {
         try {
-            const url = `${this.INTEGRATION_TRANSFORM_URL}/persistence/${request.resourceType}`;
+            // const url = `${this.INTEGRATION_TRANSFORM_URL}/persistence/${request.resourceType}`;
+            const url = `${this.INTEGRATION_TRANSFORM_URL}`;
+            console.log('POST URL', url);
             const response = await axios.post(url, request.resource);
             return { message: '', resource: response.data.resource };
         } catch (e) {

--- a/src/dataServices/apiDataService.ts
+++ b/src/dataServices/apiDataService.ts
@@ -28,8 +28,6 @@ export class ApiDataService implements Persistence {
     async createResource(request: CreateResourceRequest): Promise<GenericResponse> {
         try {
             const url = `${this.INTEGRATION_TRANSFORM_URL}/persistence/${request.resourceType}`;
-            // const url = `${this.INTEGRATION_TRANSFORM_URL}`;
-            console.log('POST URL', url);
             const response = await axios.post(url, request.resource);
             return { message: '', resource: response.data.resource };
         } catch (e) {

--- a/src/dataServices/apiDataService.ts
+++ b/src/dataServices/apiDataService.ts
@@ -20,7 +20,7 @@ export class ApiDataService implements Persistence {
 
     private axiosInstance: AxiosInstance;
 
-    constructor(integrationTransformUrl: string, axiosInstance: AxiosInstance | undefined = undefined) {
+    constructor(integrationTransformUrl: string, axiosInstance?: AxiosInstance) {
         const instance = axiosInstance ?? axios.create({ baseURL: integrationTransformUrl });
         new IamAuth().attachInterceptor(instance);
         this.axiosInstance = instance;

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,6 +463,11 @@
   dependencies:
     type-detect "4.0.8"
 
+"@types/aws4@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@types/aws4/-/aws4-1.5.1.tgz#361fadab198a030ab398269183ae3fa86e958ed9"
+  integrity sha1-Nh+tqxmKAwqzmCaRg64/qG6Vjtk=
+
 "@types/babel__core@^7.1.7":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
@@ -565,11 +570,6 @@
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
-
-"@types/promise.allsettled@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/promise.allsettled/-/promise.allsettled-1.0.3.tgz#6f3166618226a570b98c8250fc78687a912e56d5"
-  integrity sha512-b/IFHHTkYkTqu41IH9UtpICwqrpKj2oNlb4KHPzFQDMiz+h1BgAeATeO0/XTph4+UkH9W2U0E4B4j64KWOovag==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -793,16 +793,6 @@ array.prototype.flat@^1.2.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-array.prototype.map@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array.prototype.map/-/array.prototype.map-1.0.2.tgz#9a4159f416458a23e9483078de1106b2ef68f8ec"
-  integrity sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    es-array-method-boxes-properly "^1.0.0"
-    is-string "^1.0.4"
-
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -840,10 +830,24 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
+aws4-axios@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/aws4-axios/-/aws4-axios-1.12.0.tgz#9ba3562f4d04399402931be1a0f1274b0f89a3f3"
+  integrity sha512-7yTZYWqc6Sy4/B8i0t12vgHD6hnjzn5Bu1c+TO4ZoJYGQIIuJephSSHkWCBUiStznueF56gRc9Nm/KGwsfnwpA==
+  dependencies:
+    "@types/aws4" "^1.5.1"
+    aws4 "^1.9.1"
+    axios "^0.19.2"
+
 aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+
+aws4@^1.9.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
+  integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
 axios-mock-adapter@^1.18.2:
   version "1.18.2"
@@ -852,6 +856,13 @@ axios-mock-adapter@^1.18.2:
   dependencies:
     fast-deep-equal "^3.1.1"
     is-buffer "^2.0.3"
+
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 axios@^0.20.0:
   version "0.20.0"
@@ -1245,6 +1256,13 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1377,7 +1395,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstract@^1.17.5:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
   version "1.17.6"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
   integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
@@ -1393,24 +1411,6 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstrac
     object.assign "^4.1.0"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
-
-es-array-method-boxes-properly@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
-  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
-
-es-get-iterator@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.0.tgz#bb98ad9d6d63b31aacdc8f89d5d0ee57bcb5b4c8"
-  integrity sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==
-  dependencies:
-    es-abstract "^1.17.4"
-    has-symbols "^1.0.1"
-    is-arguments "^1.0.4"
-    is-map "^2.0.1"
-    is-set "^2.0.1"
-    is-string "^1.0.5"
-    isarray "^2.0.5"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -1740,10 +1740,8 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-1.0.0.tgz#7de73929ebab013745582518f7596607c85a4ad0"
-  integrity sha512-b+B7D4/Msfzku/efM7dhbqCANEjCEKqUm7YJwEsQVjfmNbyRHWNmk+Mer89POmPnbw0eqryjnvV7C698C/8+rQ==
+"fhir-works-on-aws-interface@file:.yalc/fhir-works-on-aws-interface":
+  version "2.0.0"
 
 figures@^3.0.0:
   version "3.2.0"
@@ -1804,6 +1802,13 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.10.0:
   version "1.13.0"
@@ -2124,11 +2129,6 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-arguments@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
-  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -2237,11 +2237,6 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-map@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
-  integrity sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==
-
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -2268,11 +2263,6 @@ is-regex@^1.1.0:
   dependencies:
     has-symbols "^1.0.1"
 
-is-set@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.1.tgz#d1604afdab1724986d30091575f54945da7e5f43"
-  integrity sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==
-
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -2283,7 +2273,7 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
-is-string@^1.0.4, is-string@^1.0.5:
+is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
@@ -2316,11 +2306,6 @@ isarray@1.0.0, isarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2384,19 +2369,6 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-iterate-iterator@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
-  integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
-
-iterate-value@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
-  integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
-  dependencies:
-    es-get-iterator "^1.0.2"
-    iterate-iterator "^1.0.1"
 
 jest-changed-files@^25.5.0:
   version "25.5.0"
@@ -3470,17 +3442,6 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
-promise.allsettled@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.2.tgz#d66f78fbb600e83e863d893e98b3d4376a9c47c9"
-  integrity sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==
-  dependencies:
-    array.prototype.map "^1.0.1"
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    iterate-value "^1.0.0"
 
 prompts@^2.0.1:
   version "2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1740,8 +1740,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-"fhir-works-on-aws-interface@file:.yalc/fhir-works-on-aws-interface":
+fhir-works-on-aws-interface@^2.0.0:
   version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-2.0.0.tgz#98c04208c32653f9d75743663c036f1d6eae6ffb"
+  integrity sha512-hdjZJaNEoSYXYVEDOtCQW/HxnQhnF2Nu02nzgeNEWdsZN8MiMakmLX/JxnPYmG13/L9J69CpeV1PmZCsT9HG3g==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
**Issue #, if available:**
FHIR-370

**Description of changes:**

Added `aws4-axio`. This library adds an interceptor to `axios` that enables `IAM Auth`. It uses the current `IAM role` assumed by the `lambda` function to add Auth token to each request.

Integration Transform then uses the Auth token to Authenticate the request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.