### PR TITLE
feat: Add startCrawler Lambda

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,12 @@ module.exports = {
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'error',
         'import/prefer-default-export': 'off',
-        'import/no-extraneous-dependencies': ['error', {'devDependencies': ['**/*.test.ts']}]
+        'import/no-extraneous-dependencies': ['error', {'devDependencies': ['**/*.test.ts']}],
+        // @types/aws-lambda is special since aws-lambda is not the name of a package that we take as a dependency.
+        // Making eslint recognize it would require several additional plugins and it's not worth setting it up right now.
+        // See https://github.com/typescript-eslint/typescript-eslint/issues/1624
+        // eslint-disable-next-line import/no-unresolved
+        'import/no-unresolved': ['error', { ignore: ['aws-lambda'] }],
     },
     settings: {
         'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "7",
+    "@types/aws-lambda": "^8.10.63",
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",

--- a/src/bulkExport/startCrawler.ts
+++ b/src/bulkExport/startCrawler.ts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Handler } from 'aws-lambda';
+import AWS from 'aws-sdk';
+
+export const startCrawlerHandler: Handler = async event => {
+    const { CRAWLER_NAME } = process.env;
+    if (CRAWLER_NAME === undefined) {
+        throw new Error('CRAWLER_NAME environment variable is not defined');
+    }
+    const glue = new AWS.Glue();
+    try {
+        console.log(`Starting crawler ${CRAWLER_NAME}`);
+        await glue
+            .startCrawler({
+                Name: CRAWLER_NAME,
+            })
+            .promise();
+        console.log('Crawler started successfully');
+        return event;
+    } catch (e) {
+        if (e.code === 'CrawlerRunningException') {
+            console.log('Crawler is already running');
+            return event;
+        }
+        throw e;
+    }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './dataServices/dynamoDbUtil';
 export { DynamoDb } from './dataServices/dynamoDb';
 export * from './objectStorageService/s3DataService';
 export { handleDdbToEsEvent } from './ddbToEs/index';
+export { startCrawlerHandler } from './bulkExport/startCrawler';

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,6 +515,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@types/aws-lambda@^8.10.63":
+  version "8.10.63"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.63.tgz#3316174e7a23b8505d1b7bdc979a5c3030d5e203"
+  integrity sha512-XEE+3iJxyeCmZTUoHZRbnxSy8aMxXXwrALgsoDBGcgkbll+8bDfuk4XbIJ9Oaec/Pxee6rno6SGMiV6EbqhF+A==
+
 "@types/babel__core@^7.1.7":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"


### PR DESCRIPTION
Description of changes:

Add the handler code for the `startCrawlerLambda`

bulk export requests will be served by a step functions state machine. The `startCrawlerLambda` is the first step, it simply starts a crawler and exits.

The `startCrawlerLambda` doesn't require any parameters and it could have an empty response since the only thing that matters is if the crawler started successfully. However, it accepts an event and it echoes the same event as a response. In step functions the output of one step is the input of the next one so echoing the input will be useful later on.

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/120

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.