### PR TITLE
feat: add lambda fns to start glue jobs and check its status

### DIFF
--- a/src/bulkExport/getJobStatus.test.ts
+++ b/src/bulkExport/getJobStatus.test.ts
@@ -1,0 +1,150 @@
+import * as AWSMock from 'aws-sdk-mock';
+import AWS from 'aws-sdk';
+import { QueryInput } from 'aws-sdk/clients/dynamodb';
+import { getJobStatusHandler } from './getJobStatus';
+import { BulkExportStateMachineGlobalParameters } from './types';
+import { DynamoDBConverter } from '../dataServices/dynamoDb';
+
+AWSMock.setSDKInstance(AWS);
+
+describe('getJobStatus', () => {
+    beforeEach(() => {
+        process.env.GLUE_JOB_NAME = 'jobName';
+        AWSMock.restore();
+    });
+
+    test('completed job', async () => {
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+            },
+        };
+        process.env.GLUE_JOB_NAME = 'jobName';
+        AWSMock.mock('Glue', 'getJobRun', (params: any, callback: Function) => {
+            callback(null, {
+                JobRun: {
+                    JobRunState: 'SUCCEEDED',
+                },
+            });
+        });
+        AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Item: DynamoDBConverter.marshall({
+                    jobId: '2a937fe2-8bb1-442b-b9be-434c94f30e15',
+                    jobStatus: 'in-progress',
+                }),
+            });
+        });
+        await expect(getJobStatusHandler(event, null as any, null as any)).resolves.toEqual({
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+                glueJobRunStatus: 'SUCCEEDED',
+                isCanceled: false,
+            },
+        });
+    });
+
+    test('failed job', async () => {
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+            },
+        };
+        AWSMock.mock('Glue', 'getJobRun', (params: any, callback: Function) => {
+            callback(null, {
+                JobRun: {
+                    JobRunState: 'FAILED',
+                },
+            });
+        });
+        AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Item: DynamoDBConverter.marshall({
+                    jobId: '2a937fe2-8bb1-442b-b9be-434c94f30e15',
+                    jobStatus: 'in-progress',
+                }),
+            });
+        });
+        await expect(getJobStatusHandler(event, null as any, null as any)).resolves.toEqual({
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+                glueJobRunStatus: 'FAILED',
+                isCanceled: false,
+            },
+        });
+    });
+
+    test('canceled job', async () => {
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+            },
+        };
+        AWSMock.mock('Glue', 'getJobRun', (params: any, callback: Function) => {
+            callback(null, {
+                JobRun: {
+                    JobRunState: 'RUNNING',
+                },
+            });
+        });
+        AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
+            callback(null, {
+                Item: DynamoDBConverter.marshall({
+                    jobId: '2a937fe2-8bb1-442b-b9be-434c94f30e15',
+                    jobStatus: 'canceling',
+                }),
+            });
+        });
+        await expect(getJobStatusHandler(event, null as any, null as any)).resolves.toEqual({
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+                glueJobRunStatus: 'RUNNING',
+                isCanceled: true,
+            },
+        });
+    });
+
+    test('missing env variables ', async () => {
+        delete process.env.GLUE_JOB_NAME;
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+            },
+        };
+        await expect(getJobStatusHandler(event, null as any, null as any)).rejects.toThrow(
+            'GLUE_JOB_NAME environment variable is not defined',
+        );
+    });
+
+    test('missing glueJobRunId ', async () => {
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+        };
+        await expect(getJobStatusHandler(event, null as any, null as any)).rejects.toThrow(
+            'executionParameters.glueJobRunId is missing in input event',
+        );
+    });
+});

--- a/src/bulkExport/getJobStatus.test.ts
+++ b/src/bulkExport/getJobStatus.test.ts
@@ -1,3 +1,8 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as AWSMock from 'aws-sdk-mock';
 import AWS from 'aws-sdk';
 import { QueryInput } from 'aws-sdk/clients/dynamodb';

--- a/src/bulkExport/getJobStatus.ts
+++ b/src/bulkExport/getJobStatus.ts
@@ -1,0 +1,47 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Handler } from 'aws-lambda';
+import AWS from 'aws-sdk';
+import { BulkExportStateMachineGlobalParameters } from './types';
+import DynamoDbParamBuilder from '../dataServices/dynamoDbParamBuilder';
+import { DynamoDBConverter } from '../dataServices/dynamoDb';
+
+export const getJobStatusHandler: Handler<
+    BulkExportStateMachineGlobalParameters,
+    BulkExportStateMachineGlobalParameters
+> = async event => {
+    const { GLUE_JOB_NAME } = process.env;
+    if (GLUE_JOB_NAME === undefined) {
+        throw new Error('GLUE_JOB_NAME environment variable is not defined');
+    }
+    const glueJobRunId = event.executionParameters?.glueJobRunId;
+    if (glueJobRunId === undefined) {
+        throw new Error('executionParameters.glueJobRunId is missing in input event');
+    }
+
+    const [getJobRunResponse, getItemResponse] = await Promise.all([
+        new AWS.Glue().getJobRun({ JobName: GLUE_JOB_NAME, RunId: glueJobRunId }).promise(),
+        new AWS.DynamoDB().getItem(DynamoDbParamBuilder.buildGetExportRequestJob(event.jobId)).promise(),
+    ]);
+
+    if (!getItemResponse.Item) {
+        // This should never happen. It'd mean that the DDB record was deleted in the middle of the bulk export state machine execution
+        // or that the wrong jobId was passed to step functions.
+        throw new Error(`FHIR bulk export job was not found for jobId=${event.jobId}`);
+    }
+
+    const { jobStatus } = DynamoDBConverter.unmarshall(getItemResponse.Item);
+    const glueJobStatus = getJobRunResponse.JobRun!.JobRunState!;
+
+    return {
+        ...event,
+        executionParameters: {
+            ...event.executionParameters,
+            glueJobRunStatus: glueJobStatus,
+            isCanceled: jobStatus === 'canceling' || jobStatus === 'canceled',
+        },
+    };
+};

--- a/src/bulkExport/startCrawler.ts
+++ b/src/bulkExport/startCrawler.ts
@@ -5,8 +5,12 @@
 
 import { Handler } from 'aws-lambda';
 import AWS from 'aws-sdk';
+import { BulkExportStateMachineGlobalParameters } from './types';
 
-export const startCrawlerHandler: Handler = async event => {
+export const startCrawlerHandler: Handler<
+    BulkExportStateMachineGlobalParameters,
+    BulkExportStateMachineGlobalParameters
+> = async event => {
     const { CRAWLER_NAME } = process.env;
     if (CRAWLER_NAME === undefined) {
         throw new Error('CRAWLER_NAME environment variable is not defined');

--- a/src/bulkExport/startExportJob.test.ts
+++ b/src/bulkExport/startExportJob.test.ts
@@ -1,0 +1,64 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import * as AWSMock from 'aws-sdk-mock';
+import AWS from 'aws-sdk';
+import { BulkExportStateMachineGlobalParameters } from './types';
+import { startExportJobHandler } from './startExportJob';
+
+AWSMock.setSDKInstance(AWS);
+
+describe('getJobStatus', () => {
+    beforeEach(() => {
+        process.env.GLUE_JOB_NAME = 'jobName';
+        AWSMock.restore();
+    });
+
+    test('start job', async () => {
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+        };
+        process.env.GLUE_JOB_NAME = 'jobName';
+        AWSMock.mock('Glue', 'startJobRun', (params: any, callback: Function) => {
+            callback(null, {
+                JobRunId: 'jr_1',
+            });
+        });
+        await expect(startExportJobHandler(event, null as any, null as any)).resolves.toEqual({
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId: 'jr_1',
+            },
+        });
+    });
+
+    test('glue exception', async () => {
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+        };
+        process.env.GLUE_JOB_NAME = 'jobName';
+        AWSMock.mock('Glue', 'startJobRun', (params: any, callback: Function) => {
+            callback(new Error('Error from Glue'));
+        });
+        await expect(startExportJobHandler(event, null as any, null as any)).rejects.toThrowError('Error from Glue');
+    });
+
+    test('missing env variables ', async () => {
+        delete process.env.GLUE_JOB_NAME;
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+        };
+        await expect(startExportJobHandler(event, null as any, null as any)).rejects.toThrow(
+            'GLUE_JOB_NAME environment variable is not defined',
+        );
+    });
+});

--- a/src/bulkExport/startExportJob.ts
+++ b/src/bulkExport/startExportJob.ts
@@ -22,8 +22,11 @@ export const startExportJobHandler: Handler<
             Arguments: {
                 jobId: event.jobId,
                 exportType: event.exportType,
+                transactionTime: event.transactionTime,
+                groupId: event.groupId!,
                 since: event.since!,
                 type: event.type!,
+                outputFormat: event.outputFormat!,
             },
         })
         .promise();

--- a/src/bulkExport/startExportJob.ts
+++ b/src/bulkExport/startExportJob.ts
@@ -1,0 +1,27 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Handler } from 'aws-lambda';
+import AWS from 'aws-sdk';
+import { BulkExportStateMachineGlobalParameters } from './types';
+
+export const startExportJobHandler: Handler<
+    BulkExportStateMachineGlobalParameters,
+    BulkExportStateMachineGlobalParameters
+> = async event => {
+    const { GLUE_JOB_NAME } = process.env;
+    if (GLUE_JOB_NAME === undefined) {
+        throw new Error('GLUE_JOB_NAME environment variable is not defined');
+    }
+    const glue = new AWS.Glue();
+    const startJobRunResponse = await glue.startJobRun({ JobName: GLUE_JOB_NAME }).promise();
+    return {
+        ...event,
+        executionParameters: {
+            ...event.executionParameters,
+            glueJobRunId: startJobRunResponse.JobRunId,
+        },
+    };
+};

--- a/src/bulkExport/startExportJob.ts
+++ b/src/bulkExport/startExportJob.ts
@@ -16,7 +16,17 @@ export const startExportJobHandler: Handler<
         throw new Error('GLUE_JOB_NAME environment variable is not defined');
     }
     const glue = new AWS.Glue();
-    const startJobRunResponse = await glue.startJobRun({ JobName: GLUE_JOB_NAME }).promise();
+    const startJobRunResponse = await glue
+        .startJobRun({
+            JobName: GLUE_JOB_NAME,
+            Arguments: {
+                jobId: event.jobId,
+                exportType: event.exportType,
+                since: event.since!,
+                type: event.type!,
+            },
+        })
+        .promise();
     return {
         ...event,
         executionParameters: {

--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { ExportType } from 'fhir-works-on-aws-interface';
+import { JobRunState } from 'aws-sdk/clients/glue';
+
+/**
+ * Bulk export state machine parameters.
+ * All lambda functions in the state machine are expected to use this type as both input and output
+ */
+export interface BulkExportStateMachineGlobalParameters {
+    jobId: string;
+    exportType: ExportType;
+    transactionTime: string;
+    requestQueryParams?: {
+        _outputFormat?: string;
+        _since?: string;
+        _type?: string;
+    };
+    executionParameters?: BulkExportStateMachineExecutionParameters;
+}
+
+/**
+ * Outputs of intermediate steps of the state machine execution that can be used as parameters for subsequent steps
+ */
+export interface BulkExportStateMachineExecutionParameters {
+    glueJobRunId?: string;
+    glueJobRunStatus?: JobRunState;
+    isCanceled?: boolean;
+}

--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -13,11 +13,9 @@ export interface BulkExportStateMachineGlobalParameters {
     jobId: string;
     exportType: ExportType;
     transactionTime: string;
-    requestQueryParams?: {
-        _outputFormat?: string;
-        _since?: string;
-        _type?: string;
-    };
+    outputFormat?: string;
+    since?: string;
+    type?: string;
     executionParameters?: BulkExportStateMachineExecutionParameters;
 }
 

--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -13,6 +13,7 @@ export interface BulkExportStateMachineGlobalParameters {
     jobId: string;
     exportType: ExportType;
     transactionTime: string;
+    groupId?: string;
     outputFormat?: string;
     since?: string;
     type?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,5 @@ export { DynamoDb } from './dataServices/dynamoDb';
 export * from './objectStorageService/s3DataService';
 export { handleDdbToEsEvent } from './ddbToEs/index';
 export { startCrawlerHandler } from './bulkExport/startCrawler';
+export { startExportJobHandler } from './bulkExport/startExportJob';
+export { getJobStatusHandler } from './bulkExport/getJobStatus';


### PR DESCRIPTION
Description of changes:

Added 2 more lambdas that'll be part of the bulk export state machine:
- **startExportJob**: Starts the Glue etl job.
- **getJobStatus**: Gets the Glue job status and also checks if the bulk export request has been canceled by the user. The state machine will use this info to determine the next step.

Also added types to standardize the inputs/outputs of all the step functions lambdas.

Some minor changes may be needed later on once we have the actual Glue etl script.

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/122


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.