### PR TITLE
feat: add s3 presigned urls to bulk export status response

### DIFF
--- a/src/bulkExport/__mocks__/bulkExportResults.ts
+++ b/src/bulkExport/__mocks__/bulkExportResults.ts
@@ -1,0 +1,8 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getBulkExportResults = async (jobId: string): Promise<{ type: string; url: string }[]> => {
+    return [];
+};

--- a/src/bulkExport/bulkExportResults.test.ts
+++ b/src/bulkExport/bulkExportResults.test.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 import * as AWSMock from 'aws-sdk-mock';
-import AWS from 'aws-sdk';
+import AWS from '../AWS';
 import { getBulkExportResults } from './bulkExportResults';
 
 AWSMock.setSDKInstance(AWS);

--- a/src/bulkExport/bulkExportResults.test.ts
+++ b/src/bulkExport/bulkExportResults.test.ts
@@ -1,0 +1,61 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import * as AWSMock from 'aws-sdk-mock';
+import AWS from 'aws-sdk';
+import { getBulkExportResults } from './bulkExportResults';
+
+AWSMock.setSDKInstance(AWS);
+
+describe('getBulkExportResults', () => {
+    beforeEach(() => {
+        process.env.GLUE_JOB_NAME = 'jobName';
+        AWSMock.restore();
+
+        AWSMock.mock('STS', 'assumeRole', (params: any, callback: Function) => {
+            callback(null, {
+                Credentials: { AccessKeyId: 'xxx', SecretAccessKey: 'xxx', SessionToken: 'xxx' },
+            });
+        });
+
+        AWSMock.mock('S3', 'getSignedUrl', (apiCallToSign: any, params: any, callback: Function) => {
+            callback(null, 'https://somePresignedUrl');
+        });
+    });
+
+    test('happy case', async () => {
+        AWSMock.mock('S3', 'listObjectsV2', (params: any, callback: Function) => {
+            callback(null, {
+                Contents: [{ Key: 'job-1/Patient-1.ndjson' }, { Key: 'job-1/Observation-1.ndjson' }],
+            });
+        });
+
+        await expect(getBulkExportResults('job-1')).resolves.toEqual([
+            { type: 'Patient', url: 'https://somePresignedUrl' },
+            { type: 'Observation', url: 'https://somePresignedUrl' },
+        ]);
+    });
+
+    test('no results', async () => {
+        AWSMock.mock('S3', 'listObjectsV2', (params: any, callback: Function) => {
+            callback(null, {
+                Contents: [],
+            });
+        });
+
+        await expect(getBulkExportResults('job-1')).resolves.toEqual([]);
+    });
+
+    test('filenames with unknown format', async () => {
+        AWSMock.mock('S3', 'listObjectsV2', (params: any, callback: Function) => {
+            callback(null, {
+                Contents: [{ Key: 'job-1/BadFilenameFormat$$.exe' }, { Key: 'job-1/Observation-1.ndjson' }],
+            });
+        });
+
+        await expect(getBulkExportResults('job-1')).rejects.toThrowError(
+            'Could not parse the name of bulk exports result file: job-1/BadFilenameFormat$$.exe',
+        );
+    });
+});

--- a/src/bulkExport/bulkExportResults.ts
+++ b/src/bulkExport/bulkExportResults.ts
@@ -49,7 +49,7 @@ const signExportResults = async (keys: string[]): Promise<{ key: string; url: st
 };
 
 const getResourceType = (key: string, jobId: string): string => {
-    const regex = new RegExp(`^${jobId}/([A-Za-z]+)-.*$`);
+    const regex = new RegExp(`^${jobId}/([A-Za-z]+)-\\d+.ndjson$`);
     const match = regex.exec(key);
     if (match === null) {
         throw new Error(`Could not parse the name of bulk exports result file: ${key}`);

--- a/src/bulkExport/bulkExportResults.ts
+++ b/src/bulkExport/bulkExportResults.ts
@@ -2,7 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-import AWS from 'aws-sdk';
+import AWS from '../AWS';
 
 const EXPIRATION_TIME_SECONDS = 1800;
 const EXPORT_RESULTS_BUCKET = process.env.EXPORT_RESULTS_BUCKET || ' ';

--- a/src/bulkExport/bulkExportResults.ts
+++ b/src/bulkExport/bulkExportResults.ts
@@ -11,8 +11,8 @@ const EXPORT_RESULTS_SIGNER_ROLE_ARN = process.env.EXPORT_RESULTS_SIGNER_ROLE_AR
 const getFiles = async (jobId: string): Promise<string[]> => {
     const s3 = new AWS.S3();
 
-    const listObjecsResult = await s3.listObjectsV2({ Bucket: EXPORT_RESULTS_BUCKET, Prefix: jobId }).promise();
-    return listObjecsResult.Contents!.map(x => x.Key!);
+    const listObjectsResult = await s3.listObjectsV2({ Bucket: EXPORT_RESULTS_BUCKET, Prefix: jobId }).promise();
+    return listObjectsResult.Contents!.map(x => x.Key!);
 };
 
 const signExportResults = async (keys: string[]): Promise<{ key: string; url: string }[]> => {

--- a/src/bulkExport/bulkExportResults.ts
+++ b/src/bulkExport/bulkExportResults.ts
@@ -1,0 +1,67 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import AWS from 'aws-sdk';
+
+const EXPIRATION_TIME_SECONDS = 1800;
+const EXPORT_RESULTS_BUCKET = process.env.EXPORT_RESULTS_BUCKET || ' ';
+const EXPORT_RESULTS_SIGNER_ROLE_ARN = process.env.EXPORT_RESULTS_SIGNER_ROLE_ARN || '';
+
+const getFiles = async (jobId: string): Promise<string[]> => {
+    const s3 = new AWS.S3();
+
+    const listObjecsResult = await s3.listObjectsV2({ Bucket: EXPORT_RESULTS_BUCKET, Prefix: jobId }).promise();
+    return listObjecsResult.Contents!.map(x => x.Key!);
+};
+
+const signExportResults = async (keys: string[]): Promise<{ key: string; url: string }[]> => {
+    if (keys.length === 0) {
+        return [];
+    }
+    const sts = new AWS.STS();
+    const assumeRoleResponse = await sts
+        .assumeRole({
+            RoleArn: EXPORT_RESULTS_SIGNER_ROLE_ARN,
+            RoleSessionName: 'signBulkExportResults',
+            DurationSeconds: EXPIRATION_TIME_SECONDS,
+        })
+        .promise();
+
+    const s3 = new AWS.S3({
+        credentials: {
+            accessKeyId: assumeRoleResponse.Credentials!.AccessKeyId,
+            secretAccessKey: assumeRoleResponse.Credentials!.SecretAccessKey,
+            sessionToken: assumeRoleResponse.Credentials!.SessionToken,
+        },
+    });
+
+    return Promise.all(
+        keys.map(async key => ({
+            key,
+            url: await s3.getSignedUrlPromise('getObject', {
+                Bucket: EXPORT_RESULTS_BUCKET,
+                Key: key,
+                Expires: EXPIRATION_TIME_SECONDS,
+            }),
+        })),
+    );
+};
+
+const getResourceType = (key: string, jobId: string): string => {
+    const regex = new RegExp(`^${jobId}/([A-Za-z]+)-.*$`);
+    const match = regex.exec(key);
+    if (match === null) {
+        throw new Error(`Could not parse the name of bulk exports result file: ${key}`);
+    }
+    return match[1];
+};
+
+export const getBulkExportResults = async (jobId: string): Promise<{ type: string; url: string }[]> => {
+    const keys = await getFiles(jobId);
+    const signedUrls = await signExportResults(keys);
+    return signedUrls.map(({ key, url }) => ({
+        type: getResourceType(key, jobId),
+        url,
+    }));
+};

--- a/src/dataServices/dynamoDbDataService.test.ts
+++ b/src/dataServices/dynamoDbDataService.test.ts
@@ -27,6 +27,7 @@ import { DynamoDBConverter } from './dynamoDb';
 import DynamoDbHelper from './dynamoDbHelper';
 import DynamoDbParamBuilder from './dynamoDbParamBuilder';
 
+jest.mock('../bulkExport/bulkExportResults');
 AWSMock.setSDKInstance(AWS);
 
 // eslint-disable-next-line import/order
@@ -461,7 +462,6 @@ describe('getExportStatus', () => {
         AWSMock.mock('DynamoDB', 'getItem', (params: QueryInput, callback: Function) => {
             callback(null, {
                 Item: DynamoDBConverter.marshall({
-                    s3PresignedUrls: [],
                     jobFailedMessage: '',
                     outputFormat: 'ndjson',
                     exportType: 'system',

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -35,6 +35,7 @@ import { DynamoDbBundleService } from './dynamoDbBundleService';
 import { DynamoDbUtil } from './dynamoDbUtil';
 import DynamoDbParamBuilder from './dynamoDbParamBuilder';
 import DynamoDbHelper from './dynamoDbHelper';
+import { getBulkExportResults } from '../bulkExport/bulkExportResults';
 
 export class DynamoDbDataService implements Persistence, BulkDataAccess {
     private readonly MAXIMUM_SYSTEM_LEVEL_CONCURRENT_REQUESTS = 2;
@@ -230,7 +231,6 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
         const {
             jobStatus,
             jobOwnerId,
-            s3PresignedUrls,
             transactionTime,
             exportType,
             outputFormat,
@@ -241,10 +241,12 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
             errorMessage = '',
         } = item;
 
+        const exportedFileUrls = await getBulkExportResults(jobId);
+
         const getExportStatusResponse: GetExportStatusResponse = {
             jobOwnerId,
             jobStatus,
-            exportedFileUrls: s3PresignedUrls,
+            exportedFileUrls,
             transactionTime,
             exportType,
             outputFormat,


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Export results are stored in with the following name format: `<jobId>/<Resource-Type>-<file #>.ndjson`

This lists the objects for a given jobId, generates presigned urls and returns them as part of the `$export/<jobId>` response.

Note: I'm not a fan of the `const SOME_ENV_VAR = process.env.SOME_ENV_VAR || ''` approach. Ideally this package shouldn't be aware of env variables and just receive all those vars as function/constructor params. However, this package consumes env variables in many places and doing such refactor is out of scope for this PR.

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/127

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.