### PR TITLE
fix: Proper formatted params for Glue Job

### DIFF
--- a/src/bulkExport/startExportJob.ts
+++ b/src/bulkExport/startExportJob.ts
@@ -15,18 +15,19 @@ export const startExportJobHandler: Handler<
     if (GLUE_JOB_NAME === undefined) {
         throw new Error('GLUE_JOB_NAME environment variable is not defined');
     }
+
     const glue = new AWS.Glue();
     const startJobRunResponse = await glue
         .startJobRun({
             JobName: GLUE_JOB_NAME,
             Arguments: {
-                jobId: event.jobId,
-                exportType: event.exportType,
-                transactionTime: event.transactionTime,
-                groupId: event.groupId!,
-                since: event.since!,
-                type: event.type!,
-                outputFormat: event.outputFormat!,
+                '--jobId': event.jobId,
+                '--exportType': event.exportType,
+                '--transactionTime': event.transactionTime,
+                '--groupId': event.groupId!,
+                '--since': event.since!,
+                '--type': event.type!,
+                '--outputFormat': event.outputFormat!,
             },
         })
         .promise();


### PR DESCRIPTION
Description of changes:
Proper formatted params for Glue Job. The parameter we pass in needs the prefix `--` for the python script to read the values correctly. [link here](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html)

This works as expected with the Python export script when I tested it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.