### PR TITLE
feat: add bulk export getCrawlerStatus lambda

### DIFF
--- a/src/bulkExport/getCrawlerStatus.test.ts
+++ b/src/bulkExport/getCrawlerStatus.test.ts
@@ -1,0 +1,64 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import * as AWSMock from 'aws-sdk-mock';
+import AWS from 'aws-sdk';
+import each from 'jest-each';
+import { BulkExportStateMachineGlobalParameters } from './types';
+import { getCrawlerStatusHandler } from './getCrawlerStatus';
+
+AWSMock.setSDKInstance(AWS);
+
+describe('getCrawlerStatusHandler', () => {
+    beforeEach(() => {
+        process.env.CRAWLER_NAME = 'crawlerName';
+        AWSMock.restore();
+    });
+
+    each([
+        ['READY', 'SUCCEEDED', 'succeeded'],
+        ['READY', 'CANCELLED', 'failed'],
+        ['READY', 'FAILED', 'failed'],
+        ['RUNNING', '**any**', 'running'],
+        ['STOPPING', '**any**', 'running'],
+    ]).test('State=%s, LastCrawl.Status=%s => %s', async (state: string, lastStatus: string, expected: string) => {
+        AWSMock.mock('Glue', 'getCrawler', (params: any, callback: Function) => {
+            callback(null, {
+                Crawler: {
+                    LastCrawl: {
+                        Status: lastStatus,
+                    },
+                    State: state,
+                },
+            });
+        });
+
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+        };
+        await expect(getCrawlerStatusHandler(event, null as any, null as any)).resolves.toEqual({
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                crawlerStatus: expected,
+            },
+        });
+    });
+
+    test('missing env variables', async () => {
+        delete process.env.CRAWLER_NAME;
+
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+        };
+        await expect(getCrawlerStatusHandler(event, null as any, null as any)).rejects.toThrowError(
+            'CRAWLER_NAME environment variable is not defined',
+        );
+    });
+});

--- a/src/bulkExport/getCrawlerStatus.ts
+++ b/src/bulkExport/getCrawlerStatus.ts
@@ -1,0 +1,65 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Handler } from 'aws-lambda';
+import AWS from 'aws-sdk';
+import { GetCrawlerResponse } from 'aws-sdk/clients/glue';
+import { BulkExportStateMachineGlobalParameters } from './types';
+
+/**
+ * This function combines the Crawler state and last crawl status into a simple status that is meaningful to our state machine.
+ *
+ * There is no way to get the status of a status of a specific "Crawler run". Crawlers only expose the status of the last crawl
+ * @param getCrawlerResponse
+ */
+const getCrawlerStatus = (getCrawlerResponse: GetCrawlerResponse): 'succeeded' | 'failed' | 'running' => {
+    const crawlerState = getCrawlerResponse.Crawler!.State!;
+    const lastCrawlStatus = getCrawlerResponse.Crawler!.LastCrawl!.Status!;
+    switch (crawlerState) {
+        case 'READY':
+            switch (lastCrawlStatus) {
+                case 'SUCCEEDED':
+                    return 'succeeded';
+                case 'CANCELLED':
+                case 'FAILED':
+                    return 'failed';
+                default:
+                    // This should never happen per the current Glue API specification
+                    throw new Error(`Unknown last crawl status: ${lastCrawlStatus}`);
+            }
+        case 'RUNNING':
+        case 'STOPPING':
+            return 'running';
+        default:
+            // This should never happen per the current Glue API specification
+            throw new Error(`Unknown crawler state: ${crawlerState}`);
+    }
+};
+
+export const getCrawlerStatusHandler: Handler<
+    BulkExportStateMachineGlobalParameters,
+    BulkExportStateMachineGlobalParameters
+> = async event => {
+    const { CRAWLER_NAME } = process.env;
+    if (CRAWLER_NAME === undefined) {
+        throw new Error('CRAWLER_NAME environment variable is not defined');
+    }
+    const glue = new AWS.Glue();
+    const getCrawlerResponse = await glue
+        .getCrawler({
+            Name: CRAWLER_NAME,
+        })
+        .promise();
+
+    const crawlerStatus = getCrawlerStatus(getCrawlerResponse);
+
+    return {
+        ...event,
+        executionParameters: {
+            ...event.executionParameters,
+            crawlerStatus,
+        },
+    };
+};

--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -27,4 +27,5 @@ export interface BulkExportStateMachineExecutionParameters {
     glueJobRunId?: string;
     glueJobRunStatus?: JobRunState;
     isCanceled?: boolean;
+    crawlerStatus?: 'succeeded' | 'failed' | 'running';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export { startCrawlerHandler } from './bulkExport/startCrawler';
 export { startExportJobHandler } from './bulkExport/startExportJob';
 export { getJobStatusHandler } from './bulkExport/getJobStatus';
 export { updateStatusStatusHandler } from './bulkExport/updateStatus';
+export { getCrawlerStatusHandler } from './bulkExport/getCrawlerStatus';


### PR DESCRIPTION
Description of changes:

Another lambda function that'll be part of the bulk export state machine. 

This lambda function simply checks the status of the crawler that was started earlier by the `startCrawler` task and reports the status on its response. The state machine will use this status to decide the next step

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/130

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.