### PR TITLE
Bulk export stop job

### DIFF
--- a/src/bulkExport/stopExportJob.test.ts
+++ b/src/bulkExport/stopExportJob.test.ts
@@ -1,0 +1,74 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import * as AWSMock from 'aws-sdk-mock';
+import AWS from 'aws-sdk';
+import { BulkExportStateMachineGlobalParameters } from './types';
+import { stopExportJobHandler } from './stopExportJob';
+
+AWSMock.setSDKInstance(AWS);
+
+describe('getJobStatus', () => {
+    beforeEach(() => {
+        process.env.GLUE_JOB_NAME = 'jobName';
+        AWSMock.restore();
+    });
+
+    test('stop job successfully', async () => {
+        const glueJobRunId = 'jr_1';
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId,
+            },
+        };
+        const glueJobName = 'jobName';
+        process.env.GLUE_JOB_NAME = glueJobName;
+
+        AWSMock.mock('Glue', 'batchStopJobRun', (params: any, callback: Function) => {
+            callback(null, {
+                SuccessfulSubmissions: [
+                    {
+                        JobName: glueJobName,
+                        JobRunId: glueJobRunId,
+                    },
+                ],
+                Errors: [],
+            });
+        });
+        await expect(stopExportJobHandler(event, null as any, null as any)).resolves.not.toThrowError();
+    });
+    test('stop job failed', async () => {
+        const glueJobRunId = 'jr_1';
+        const event: BulkExportStateMachineGlobalParameters = {
+            jobId: '1',
+            exportType: 'system',
+            transactionTime: '',
+            executionParameters: {
+                glueJobRunId,
+            },
+        };
+        const glueJobName = 'jobName';
+        process.env.GLUE_JOB_NAME = glueJobName;
+
+        AWSMock.mock('Glue', 'batchStopJobRun', (params: any, callback: Function) => {
+            callback(null, {
+                SuccessfulSubmissions: [],
+                Errors: [
+                    {
+                        JobName: glueJobName,
+                        JobRunId: glueJobRunId,
+                        ErrorDetail: {
+                            ErrorCode: 'JobRunCannotBeStoppedException',
+                            ErrorMessage: 'Job Run cannot be stopped in current state.',
+                        },
+                    },
+                ],
+            });
+        });
+        await expect(stopExportJobHandler(event, null as any, null as any)).rejects.toThrow('Failed to stop job');
+    });
+});

--- a/src/bulkExport/stopExportJob.test.ts
+++ b/src/bulkExport/stopExportJob.test.ts
@@ -39,7 +39,7 @@ describe('getJobStatus', () => {
                 Errors: [],
             });
         });
-        await expect(stopExportJobHandler(event, null as any, null as any)).resolves.not.toThrowError();
+        await expect(stopExportJobHandler(event, null as any, null as any)).resolves.toEqual({ jobId: '1' });
     });
     test('stop job failed', async () => {
         const glueJobRunId = 'jr_1';

--- a/src/bulkExport/stopExportJob.ts
+++ b/src/bulkExport/stopExportJob.ts
@@ -26,7 +26,7 @@ export const stopExportJobHandler: Handler<BulkExportStateMachineGlobalParameter
         .promise();
     if (stopJobRunResponse.Errors!.length > 0) {
         console.log('Failed to stop job', JSON.stringify(stopJobRunResponse));
-        throw new Error(`Failed to stop job`);
+        throw new Error(`Failed to stop job ${glueJobRunId}`);
     }
     return {
         jobId: event.jobId,

--- a/src/bulkExport/stopExportJob.ts
+++ b/src/bulkExport/stopExportJob.ts
@@ -7,10 +7,7 @@ import { Handler } from 'aws-lambda';
 import AWS from 'aws-sdk';
 import { BulkExportStateMachineGlobalParameters } from './types';
 
-export const stopExportJobHandler: Handler<
-    BulkExportStateMachineGlobalParameters,
-    BulkExportStateMachineGlobalParameters
-> = async event => {
+export const stopExportJobHandler: Handler<BulkExportStateMachineGlobalParameters, void> = async event => {
     const { GLUE_JOB_NAME } = process.env;
     if (GLUE_JOB_NAME === undefined) {
         throw new Error('GLUE_JOB_NAME environment variable is not defined');
@@ -28,13 +25,7 @@ export const stopExportJobHandler: Handler<
         })
         .promise();
     if (stopJobRunResponse.Errors!.length > 0) {
-        throw new Error(`Failed to cancel job ${stopJobRunResponse.Errors!}`);
+        console.log('Failed to stop job', JSON.stringify(stopJobRunResponse));
+        throw new Error(`Failed to stop job`);
     }
-
-    return {
-        ...event,
-        executionParameters: {
-            ...event.executionParameters,
-        },
-    };
 };

--- a/src/bulkExport/stopExportJob.ts
+++ b/src/bulkExport/stopExportJob.ts
@@ -1,0 +1,40 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Handler } from 'aws-lambda';
+import AWS from 'aws-sdk';
+import { BulkExportStateMachineGlobalParameters } from './types';
+
+export const stopExportJobHandler: Handler<
+    BulkExportStateMachineGlobalParameters,
+    BulkExportStateMachineGlobalParameters
+> = async event => {
+    const { GLUE_JOB_NAME } = process.env;
+    if (GLUE_JOB_NAME === undefined) {
+        throw new Error('GLUE_JOB_NAME environment variable is not defined');
+    }
+    const glueJobRunId = event.executionParameters?.glueJobRunId;
+    if (glueJobRunId === undefined) {
+        throw new Error('executionParameters.glueJobRunId is missing in input event');
+    }
+
+    const glue = new AWS.Glue();
+    const stopJobRunResponse = await glue
+        .batchStopJobRun({
+            JobName: GLUE_JOB_NAME,
+            JobRunIds: [glueJobRunId],
+        })
+        .promise();
+    if (stopJobRunResponse.Errors!.length > 0) {
+        throw new Error(`Failed to cancel job ${stopJobRunResponse.Errors!}`);
+    }
+
+    return {
+        ...event,
+        executionParameters: {
+            ...event.executionParameters,
+        },
+    };
+};

--- a/src/bulkExport/stopExportJob.ts
+++ b/src/bulkExport/stopExportJob.ts
@@ -7,7 +7,7 @@ import { Handler } from 'aws-lambda';
 import AWS from 'aws-sdk';
 import { BulkExportStateMachineGlobalParameters } from './types';
 
-export const stopExportJobHandler: Handler<BulkExportStateMachineGlobalParameters, void> = async event => {
+export const stopExportJobHandler: Handler<BulkExportStateMachineGlobalParameters, { jobId: string }> = async event => {
     const { GLUE_JOB_NAME } = process.env;
     if (GLUE_JOB_NAME === undefined) {
         throw new Error('GLUE_JOB_NAME environment variable is not defined');
@@ -28,4 +28,7 @@ export const stopExportJobHandler: Handler<BulkExportStateMachineGlobalParameter
         console.log('Failed to stop job', JSON.stringify(stopJobRunResponse));
         throw new Error(`Failed to stop job`);
     }
+    return {
+        jobId: event.jobId,
+    };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export * from './objectStorageService/s3DataService';
 export { handleDdbToEsEvent } from './ddbToEs/index';
 export { startCrawlerHandler } from './bulkExport/startCrawler';
 export { startExportJobHandler } from './bulkExport/startExportJob';
+export { stopExportJobHandler } from './bulkExport/stopExportJob';
 export { getJobStatusHandler } from './bulkExport/getJobStatus';
 export { updateStatusStatusHandler } from './bulkExport/updateStatus';


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Add stop export job
* The next step after this stage is `updateStatusToCanceled` [link](https://github.com/awslabs/fhir-works-on-aws-deployment/blob/f9a4e0522a68de709ccb948a54b2b530593fa582/bulkExport/state-machine-definition.yaml#L34). This step requires the value `jobId` so we're returning that value in the `stopExportJob` stage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.