### PR TITLE
fix: Set default 'since' dateTime to include milliseconds

### DIFF
--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -120,7 +120,7 @@ export default class DynamoDbParamBuilder {
             exportType: initiateExportRequest.exportType,
             groupId: initiateExportRequest.groupId ?? '',
             outputFormat: initiateExportRequest.outputFormat ?? 'ndjson',
-            since: initiateExportRequest.since ?? '1800-01-01T00:00:00Z', // Default to a long time ago in the past
+            since: initiateExportRequest.since ?? '1800-01-01T00:00:00.000Z', // Default to a long time ago in the past
             type: initiateExportRequest.type ?? '',
             transactionTime: initiateExportRequest.transactionTime,
             s3PresignedUrls: [],


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Since we're passing in `ISOString` dateTime value from the [router](https://github.com/awslabs/fhir-works-on-aws-routing/blob/bulk-export/src/router/routes/exportRouteHelper.ts#L31), so let's set the default `since` value to also be in that format.

Example ISOString `2020-10-30T15:16:56.737Z`. It includes milliseconds to 3 decimal places.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.