### PR TITLE
feat: start bulk export state machine execution

### DIFF
--- a/src/bulkExport/__mocks__/bulkExport.ts
+++ b/src/bulkExport/__mocks__/bulkExport.ts
@@ -2,7 +2,12 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
+import { BulkExportJob } from '../types';
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getBulkExportResults = async (jobId: string): Promise<{ type: string; url: string }[]> => {
     return [];
 };
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
+export const startJobExecution = async (bulkExportJob: BulkExportJob): Promise<void> => {};

--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -2,7 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-import { ExportType } from 'fhir-works-on-aws-interface';
+import { ExportJobStatus, ExportType } from 'fhir-works-on-aws-interface';
 import { JobRunState } from 'aws-sdk/clients/glue';
 
 /**
@@ -27,4 +27,18 @@ export interface BulkExportStateMachineExecutionParameters {
     glueJobRunId?: string;
     glueJobRunStatus?: JobRunState;
     isCanceled?: boolean;
+}
+
+export interface BulkExportJob {
+    jobId: string;
+    jobStatus: ExportJobStatus;
+    jobOwnerId: string;
+    exportType: ExportType;
+    transactionTime: string;
+    outputFormat: string;
+    since: string;
+    s3PresignedUrls?: any[];
+    groupId?: string;
+    jobFailedMessage?: string;
+    type?: string;
 }

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExportJobStatus, InitiateExportRequest } from 'fhir-works-on-aws-interface';
+import { ExportJobStatus } from 'fhir-works-on-aws-interface';
 import {
     DynamoDBConverter,
     RESOURCE_TABLE,
@@ -12,6 +12,7 @@ import {
 } from './dynamoDb';
 import { DynamoDbUtil, DOCUMENT_STATUS_FIELD, LOCK_END_TS_FIELD } from './dynamoDbUtil';
 import DOCUMENT_STATUS from './documentStatus';
+import { BulkExportJob } from '../bulkExport/types';
 
 export default class DynamoDbParamBuilder {
     static LOCK_DURATION_IN_MS = 35 * 1000;
@@ -109,28 +110,10 @@ export default class DynamoDbParamBuilder {
         };
     }
 
-    static buildPutCreateExportRequest(
-        jobId: string,
-        initiateExportRequest: InitiateExportRequest,
-        stepFunctionExecutionArn: string,
-    ) {
-        const item = {
-            jobId,
-            jobOwnerId: initiateExportRequest.requesterUserId,
-            exportType: initiateExportRequest.exportType,
-            groupId: initiateExportRequest.groupId ?? '',
-            outputFormat: initiateExportRequest.outputFormat ?? 'ndjson',
-            since: initiateExportRequest.since ?? '1800-01-01T00:00:00.000Z', // Default to a long time ago in the past
-            type: initiateExportRequest.type ?? '',
-            transactionTime: initiateExportRequest.transactionTime,
-            s3PresignedUrls: [],
-            stepFunctionExecutionArn,
-            jobStatus: 'in-progress',
-            jobFailedMessage: '',
-        };
+    static buildPutCreateExportRequest(bulkExportJob: BulkExportJob) {
         return {
             TableName: EXPORT_REQUEST_TABLE,
-            Item: DynamoDBConverter.marshall(item),
+            Item: DynamoDBConverter.marshall(bulkExportJob),
         };
     }
 


### PR DESCRIPTION
Start the step functions state machine execution for bulk export requests. 

Note that I removed the `stepFunctionExecutionArn` from DDB. Instead I'm passing the jobId as the execution name.
step functions optionally allows to pass a unique** name when you start the execution and that name is part of the execution ARN( `arn:aws:states:<region>:<account>:execution:<state machine name>:<execution name>`) jobId is unique so it can be used as the execution name. AFAIK the execution arn was stored in ddb only for bookkeeping/debugging and is not used anywhere.

Also did some minor refactoring since I wanted to avoid duplication of the default job values (like outputFormat=ndjson, etc.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.