### PR TITLE
feat: support AWS_REGION env var in IS_OFFLINE mode

### DIFF
--- a/src/AWS.ts
+++ b/src/AWS.ts
@@ -12,7 +12,7 @@ const AWSWithXray = AWSXRay.captureAWS(AWS);
 const { IS_OFFLINE } = process.env;
 if (IS_OFFLINE === 'true') {
     AWS.config.update({
-        region: 'us-west-2',
+        region: process.env.AWS_REGION || 'us-west-2',
         accessKeyId: process.env.ACCESS_KEY,
         secretAccessKey: process.env.SECRET_KEY,
     });

--- a/src/ddbToEs/ddbToEsHelper.ts
+++ b/src/ddbToEs/ddbToEsHelper.ts
@@ -22,10 +22,10 @@ export default class DdbToEsHelper {
     constructor() {
         let ES_DOMAIN_ENDPOINT = ELASTICSEARCH_DOMAIN_ENDPOINT || 'https://fake-es-endpoint.com';
         if (IS_OFFLINE === 'true') {
-            const { ACCESS_KEY, SECRET_KEY, OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT } = process.env;
+            const { ACCESS_KEY, SECRET_KEY, AWS_REGION, OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT } = process.env;
 
             AWS.config.update({
-                region: 'us-west-2',
+                region: AWS_REGION || 'us-west-2',
                 accessKeyId: ACCESS_KEY,
                 secretAccessKey: SECRET_KEY,
             });


### PR DESCRIPTION
Issue #36

Description of changes:

Look for the `AWS_REGION` env variable prior to defaulting to the `us-west-2` region. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.