### PR TITLE
fix: Get exported file only when jobStatus is completed

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
-    "fhir-works-on-aws-interface": "^2.0.0",
+    "fhir-works-on-aws-interface": "file:.yalc/fhir-works-on-aws-interface",
     "lodash": "^4.17.20",
     "mime-types": "^2.1.26",
     "promise.allsettled": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
-    "fhir-works-on-aws-interface": "file:.yalc/fhir-works-on-aws-interface",
+    "fhir-works-on-aws-interface": "^2.0.0",
     "lodash": "^4.17.20",
     "mime-types": "^2.1.26",
     "promise.allsettled": "^1.0.2",

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -258,7 +258,7 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
             errorMessage = '',
         } = item;
 
-        const exportedFileUrls = await getBulkExportResults(jobId);
+        const exportedFileUrls = jobStatus === 'completed' ? await getBulkExportResults(jobId) : [];
 
         const getExportStatusResponse: GetExportStatusResponse = {
             jobOwnerId,


### PR DESCRIPTION
Issue #, if available:

Description of changes:
During the Glue export job, Glue renames files in S3. If a customer calls for the export job status, we shouldn't create signed S3 urls until the Glue job is completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.