### PR TITLE
fix: Don't store presignedS3Urls

### DIFF
--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -37,7 +37,6 @@ export interface BulkExportJob {
     transactionTime: string;
     outputFormat: string;
     since: string;
-    s3PresignedUrls?: any[];
     groupId?: string;
     jobFailedMessage?: string;
     type?: string;

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -49,7 +49,6 @@ const buildExportJob = (initiateExportRequest: InitiateExportRequest): BulkExpor
         since: initiateExportRequest.since ?? '1800-01-01T00:00:00.000Z', // Default to a long time ago in the past
         type: initiateExportRequest.type ?? '',
         transactionTime: initiateExportRequest.transactionTime,
-        s3PresignedUrls: [],
         jobStatus: initialStatus,
         jobFailedMessage: '',
     };


### PR DESCRIPTION
fix: We no longer need to store presignedS3Urls as they are now dynamically generated when a user request for the S3 files

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.