### PR TITLE
feat: Add reference to data model

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,14 @@
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
     "fhir-works-on-aws-interface": "^3.0.0",
+    "flat": "^5.0.2",
     "lodash": "^4.17.20",
     "mime-types": "^2.1.26",
     "promise.allsettled": "^1.0.2",
     "uuid": "^3.4.0"
   },
   "devDependencies": {
+    "@types/flat": "^5.0.1",
     "@types/jest": "^25.1.1",
     "@types/lodash": "^4.14.161",
     "@types/mime-types": "^2.1.0",

--- a/src/dataServices/dynamoDbBundleService.test.ts
+++ b/src/dataServices/dynamoDbBundleService.test.ts
@@ -9,7 +9,6 @@ import AWSMock from 'aws-sdk-mock';
 import { QueryInput, TransactWriteItemsInput } from 'aws-sdk/clients/dynamodb';
 import * as AWS from 'aws-sdk';
 import { BundleResponse, BatchReadWriteRequest } from 'fhir-works-on-aws-interface';
-import { SinonSandbox } from 'sinon';
 import { DynamoDbBundleService } from './dynamoDbBundleService';
 import { DynamoDBConverter } from './dynamoDb';
 import { timeFromEpochInMsRegExp, utcTimeRegExp, uuidRegExp } from '../../testUtilities/regExpressions';
@@ -21,17 +20,9 @@ import sinon = require('sinon');
 AWSMock.setSDKInstance(AWS);
 
 describe('atomicallyReadWriteResources', () => {
-    let sandbox: SinonSandbox;
-    beforeEach(function() {
-        sandbox = sinon.createSandbox();
-    });
-
-    afterEach(function() {
-        sandbox.restore();
-    });
-
     afterEach(() => {
         AWSMock.restore();
+        sinon.restore();
     });
 
     const id = 'bce8411e-c15e-448c-95dd-69155a837405';
@@ -115,7 +106,7 @@ describe('atomicallyReadWriteResources', () => {
                 });
             });
 
-            const transactWriteItemStub = sandbox.stub();
+            const transactWriteItemStub = sinon.stub();
             // LOCK Items (Success)
             transactWriteItemStub.onFirstCall().returns({ error: null, value: {} });
 
@@ -144,7 +135,7 @@ describe('atomicallyReadWriteResources', () => {
         // When creating a resource, no locks is needed because no items in DDB to put a lock on yet
         async function runCreateTest(shouldReqHasReferences: boolean) {
             // BUILD
-            const transactWriteItemSpy = sandbox.spy();
+            const transactWriteItemSpy = sinon.spy();
             AWSMock.mock('DynamoDB', 'transactWriteItems', (params: TransactWriteItemsInput, callback: Function) => {
                 transactWriteItemSpy(params);
                 callback(null, {});
@@ -268,7 +259,7 @@ describe('atomicallyReadWriteResources', () => {
 
         async function runUpdateTest(shouldReqHasReferences: boolean) {
             // BUILD
-            const transactWriteItemSpy = sandbox.spy();
+            const transactWriteItemSpy = sinon.spy();
             AWSMock.mock('DynamoDB', 'transactWriteItems', (params: TransactWriteItemsInput, callback: Function) => {
                 transactWriteItemSpy(params);
                 callback(null, {});
@@ -296,7 +287,7 @@ describe('atomicallyReadWriteResources', () => {
             }
             const newResource = { ...oldResource, test: 'test' };
 
-            sandbox
+            sinon
                 .stub(DynamoDbHelper.prototype, 'getMostRecentResource')
                 .returns(Promise.resolve({ message: 'Resource found', resource: oldResource }));
 

--- a/src/dataServices/dynamoDbBundleService.test.ts
+++ b/src/dataServices/dynamoDbBundleService.test.ts
@@ -141,6 +141,7 @@ describe('atomicallyReadWriteResources', () => {
     });
 
     describe('SUCCESS Cases', () => {
+        // When creating a resource, no locks is needed because no items in DDB to put a lock on yet
         async function runCreateTest(shouldReqHasReferences: boolean) {
             // BUILD
             const transactWriteItemSpy = sandbox.spy();
@@ -257,7 +258,6 @@ describe('atomicallyReadWriteResources', () => {
                 success: true,
             });
         }
-        // When creating a resource, no locks is needed because no items in DDB to put a lock on yet
         test('CREATING a resource with no references', async () => {
             await runCreateTest(false);
         });

--- a/src/dataServices/dynamoDbParamBuilder.test.ts
+++ b/src/dataServices/dynamoDbParamBuilder.test.ts
@@ -132,8 +132,8 @@ describe('buildUpdateDocumentStatusParam', () => {
     });
 });
 
-describe('buildPutItemParam', () => {
-    test('check that param has the fields documentStatus and lockEndTs', () => {
+describe('buildPutAvailableItemParam', () => {
+    test('check that param has the fields documentStatus, lockEndTs, and references', () => {
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
         const vid = 1;
         const item = {
@@ -155,6 +155,9 @@ describe('buildPutItemParam', () => {
         const expectedParams = {
             TableName: '',
             Item: {
+                _references: {
+                    L: [],
+                },
                 resourceType: {
                     S: 'Patient',
                 },

--- a/src/dataServices/dynamoDbUtil.test.ts
+++ b/src/dataServices/dynamoDbUtil.test.ts
@@ -51,8 +51,6 @@ describe('cleanItem', () => {
 describe('prepItemForDdbInsert', () => {
     const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
     const vid = 1;
-    const organization = 'Organization/1';
-    const otherPatient = 'Patient/pat2';
     const resource = {
         resourceType: 'Patient',
         id,
@@ -84,6 +82,8 @@ describe('prepItemForDdbInsert', () => {
     };
 
     test('Return item correctly when resource to be prepped contains references', () => {
+        const organization = 'Organization/1';
+        const otherPatient = 'Patient/pat2';
         // BUILD
         const updatedResource = clone(resource);
         updatedResource.managingOrganization = {

--- a/src/dataServices/dynamoDbUtil.test.ts
+++ b/src/dataServices/dynamoDbUtil.test.ts
@@ -105,7 +105,7 @@ describe('prepItemForDdbInsert', () => {
         checkExpectedItemMatchActualItem(actualItem, updatedResource);
     });
 
-    test('FHIR Resource with referenceSeq as a field should not have field added to `_references`', () => {
+    test('Return item correctly when resource has "referenceSeq" as a field. Only resource fields named "reference" should be added to `_references`', () => {
         // BUILD
         const patient = 'Patient/pat1';
         const updatedResource: any = {
@@ -140,7 +140,6 @@ describe('prepItemForDdbInsert', () => {
 
         // CHECK
         updatedResource[REFERENCES_FIELD] = [patient];
-
         checkExpectedItemMatchActualItem(actualItem, updatedResource);
     });
 

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -49,7 +49,8 @@ export class DynamoDbUtil {
         const flattenedResources: Record<string, string> = flatten(resource);
         const references = Object.keys(flattenedResources)
             .filter((key: string) => {
-                return key.endsWith('reference');
+                return key.endsWith('.reference');
+
             })
             .map((key: string) => {
                 return flattenedResources[key];

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -50,7 +50,6 @@ export class DynamoDbUtil {
         const references = Object.keys(flattenedResources)
             .filter((key: string) => {
                 return key.endsWith('.reference');
-
             })
             .map((key: string) => {
                 return flattenedResources[key];

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -49,7 +49,7 @@ export class DynamoDbUtil {
         const flattenedResources: Record<string, string> = flatten(resource);
         const references = Object.keys(flattenedResources)
             .filter((key: string) => {
-                return key.split('.').pop() === 'reference';
+                return key.endsWith('reference');
             })
             .map((key: string) => {
                 return flattenedResources[key];

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -4,12 +4,14 @@
  */
 
 import { clone, generateMeta } from 'fhir-works-on-aws-interface';
+import flatten from 'flat';
 import { SEPARATOR } from '../constants';
 import DOCUMENT_STATUS from './documentStatus';
 
 export const DOCUMENT_STATUS_FIELD = 'documentStatus';
 export const LOCK_END_TS_FIELD = 'lockEndTs';
 export const VID_FIELD = 'vid';
+export const REFERENCES_FIELD = '_references';
 
 export class DynamoDbUtil {
     static cleanItem(item: any) {
@@ -18,6 +20,7 @@ export class DynamoDbUtil {
         delete cleanedItem[DOCUMENT_STATUS_FIELD];
         delete cleanedItem[LOCK_END_TS_FIELD];
         delete cleanedItem[VID_FIELD];
+        delete cleanedItem[REFERENCES_FIELD];
 
         // Return id instead of full id (this is only a concern in results from ES)
         const id = item.id.split(SEPARATOR)[0];
@@ -39,6 +42,19 @@ export class DynamoDbUtil {
         }
         item[DOCUMENT_STATUS_FIELD] = documentStatus;
         item[LOCK_END_TS_FIELD] = Date.now();
+
+        // Format of flattenedResource
+        // https://www.npmjs.com/package/flat
+        // flatten({ key1: { keyA: 'valueI' } })  => { key1.keyA: 'valueI'}
+        const flattenedResources: Record<string, string> = flatten(resource);
+        const references = Object.keys(flattenedResources)
+            .filter((key: string) => {
+                return key.includes('reference');
+            })
+            .map((key: string) => {
+                return flattenedResources[key];
+            });
+        item[REFERENCES_FIELD] = references;
         return item;
     }
 }

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -49,7 +49,7 @@ export class DynamoDbUtil {
         const flattenedResources: Record<string, string> = flatten(resource);
         const references = Object.keys(flattenedResources)
             .filter((key: string) => {
-                return key.includes('reference');
+                return key.split('.').pop() === 'reference';
             })
             .map((key: string) => {
                 return flattenedResources[key];

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,6 +604,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/flat@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/flat/-/flat-5.0.1.tgz#9d703bbfb59ad9ec9ce376bdeb93a0f85da27059"
+  integrity sha512-ykRODHi9G9exJdTZvQggsqCUtB7jqiwLHcXCjNMb7zgWx6Lc2bydIUYBG1+It6VXZVFaeROv6HqPjDCAsoPG3w==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"
@@ -2120,6 +2125,11 @@ flat-cache@^2.0.1:
     flatted "^2.0.0"
     rimraf "2.6.3"
     write "1.0.3"
+
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
Issue #, if available:
FHIR-439

Description of changes:
Add logic to Persistence to add _references, for all references within the object.

**A/C:**
* new updates/creates add a _references list in the DynamoDB object
* read/searches does not return _references in the result

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.