### PR TITLE
chore: Add custom user agent

### DIFF
--- a/src/AWS.ts
+++ b/src/AWS.ts
@@ -10,6 +10,11 @@ import AWS from 'aws-sdk';
 const AWSWithXray = AWSXRay.captureAWS(AWS);
 
 const { IS_OFFLINE } = process.env;
+
+AWS.config.update({
+    customUserAgent: process.env.CUSTOM_USER_AGENT,
+});
+
 if (IS_OFFLINE === 'true') {
     AWS.config.update({
         region: process.env.AWS_REGION || 'us-west-2',

--- a/src/bulkExport/getJobStatus.ts
+++ b/src/bulkExport/getJobStatus.ts
@@ -4,7 +4,8 @@
  */
 
 import { Handler } from 'aws-lambda';
-import AWS from 'aws-sdk';
+
+import AWS from '../AWS';
 import { BulkExportStateMachineGlobalParameters } from './types';
 import DynamoDbParamBuilder from '../dataServices/dynamoDbParamBuilder';
 import { DynamoDBConverter } from '../dataServices/dynamoDb';

--- a/src/bulkExport/startExportJob.ts
+++ b/src/bulkExport/startExportJob.ts
@@ -4,7 +4,7 @@
  */
 
 import { Handler } from 'aws-lambda';
-import AWS from 'aws-sdk';
+import AWS from '../AWS';
 import { BulkExportStateMachineGlobalParameters } from './types';
 
 export const startExportJobHandler: Handler<

--- a/src/bulkExport/stopExportJob.ts
+++ b/src/bulkExport/stopExportJob.ts
@@ -4,7 +4,7 @@
  */
 
 import { Handler } from 'aws-lambda';
-import AWS from 'aws-sdk';
+import AWS from '../AWS';
 import { BulkExportStateMachineGlobalParameters } from './types';
 
 export const stopExportJobHandler: Handler<BulkExportStateMachineGlobalParameters, { jobId: string }> = async event => {

--- a/src/bulkExport/updateStatus.ts
+++ b/src/bulkExport/updateStatus.ts
@@ -4,8 +4,8 @@
  */
 
 import { Handler } from 'aws-lambda';
-import AWS from 'aws-sdk';
 import { ExportJobStatus } from 'fhir-works-on-aws-interface';
+import AWS from '../AWS';
 import DynamoDbParamBuilder from '../dataServices/dynamoDbParamBuilder';
 
 const EXPORT_JOB_STATUS = ['completed', 'failed', 'in-progress', 'canceled', 'canceling'];

--- a/src/ddbToEs/ddbToEsHelper.ts
+++ b/src/ddbToEs/ddbToEsHelper.ts
@@ -4,10 +4,10 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
-import AWS from 'aws-sdk';
 // @ts-ignore
 import { AmazonConnection, AmazonTransport } from 'aws-elasticsearch-connector';
 import allSettled from 'promise.allsettled';
+import AWS from '../AWS';
 import PromiseParamAndId, { PromiseType } from './promiseParamAndId';
 import { DOCUMENT_STATUS_FIELD } from '../dataServices/dynamoDbUtil';
 import DOCUMENT_STATUS from '../dataServices/documentStatus';


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add support for custom user agent. Deployment package would pass the custom user agent to `persistence` as an environment variable.

`CUSTOM_USER_AGENT = AwsLabs/SO0128/2.4.0`

I've deployed this package to AWS. Custom Integration tests passed, crucible tests passed.

In CloudTrail for retrieving Binary resource, we can see that the `userAgent` includes `AwsLabs/SO0128/2.4.0`

```
{
    ... 
    "eventTime": "2021-03-25T18:25:22Z",
    "eventSource": "s3.amazonaws.com",
    "eventName": "HeadObject",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "34.223.63.211",
    "userAgent": "[aws-sdk-nodejs/2.804.0 linux/v12.20.1 exec-env/AWS_Lambda_nodejs12.x AwsLabs/SO0128/2.4.0 promise]",
    "requestParameters": {
        "bucketName": "fhir-service-dev-fhirbinarybucket-abc",
        "Host": "fhir-service-dev-fhirbinarybucket-abc.s3.us-west-2.amazonaws.com",
        "key": "7453f1a5-1bc6-401a-a443-4598d2f53d89_1.jpeg"
    },
    ...
    "resources": [
        {
            "type": "AWS::S3::Object",
            "ARN": "arn:aws:s3:::fhir-service-dev-fhirbinarybucket-abc/7453f1a5-1bc6-401a-a443-4598d2f53d89_1.jpeg"
        },
        {
            "accountId": "273042691419",
            "type": "AWS::S3::Bucket",
            "ARN": "arn:aws:s3:::fhir-service-dev-fhirbinarybucket-abc"
        }
    ],
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.