### PR TITLE
fix: Only add customUserAgent when code is running on AWS, not when code is running locally

### DIFF
--- a/src/AWS.ts
+++ b/src/AWS.ts
@@ -11,15 +11,15 @@ const AWSWithXray = AWSXRay.captureAWS(AWS);
 
 const { IS_OFFLINE } = process.env;
 
-AWS.config.update({
-    customUserAgent: process.env.CUSTOM_USER_AGENT,
-});
-
 if (IS_OFFLINE === 'true') {
     AWS.config.update({
         region: process.env.AWS_REGION || 'us-west-2',
         accessKeyId: process.env.ACCESS_KEY,
         secretAccessKey: process.env.SECRET_KEY,
+    });
+} else {
+    AWS.config.update({
+        customUserAgent: process.env.CUSTOM_USER_AGENT,
     });
 }
 


### PR DESCRIPTION
fix: Only add `customUserAgent` when code is running on AWS, not when code is running locally


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.