### PR TITLE
fix: return the newly create meta field from bundle processer

### DIFF
--- a/src/dataServices/dynamoDbBundleService.test.ts
+++ b/src/dataServices/dynamoDbBundleService.test.ts
@@ -221,7 +221,7 @@ describe('atomicallyReadWriteResources', () => {
                         Update: {
                             TableName: '',
                             Key: {
-                                id: { S: 'bce8411e-c15e-448c-95dd-69155a837405' },
+                                id: { S: id },
                                 vid: { N: '1' },
                             },
                             UpdateExpression: 'set documentStatus = :newStatus, lockEndTs = :futureEndTs',
@@ -235,17 +235,24 @@ describe('atomicallyReadWriteResources', () => {
                     },
                 ],
             });
-
             expect(actualResponse).toStrictEqual({
                 message: 'Successfully committed requests to DB',
                 batchReadWriteResponses: [
                     {
-                        id: 'bce8411e-c15e-448c-95dd-69155a837405',
+                        id,
                         vid: '1',
                         operation: 'create',
                         lastModified: expect.stringMatching(utcTimeRegExp),
                         resourceType: 'Patient',
-                        resource: {},
+                        resource: {
+                            ...resource,
+                            id,
+                            meta: {
+                                lastUpdated: expect.stringMatching(utcTimeRegExp),
+                                versionId: '1',
+                                security: 'gondor',
+                            },
+                        },
                     },
                 ],
                 success: true,
@@ -421,7 +428,14 @@ describe('atomicallyReadWriteResources', () => {
                         operation: 'update',
                         lastModified: expect.stringMatching(utcTimeRegExp),
                         resourceType,
-                        resource: {},
+                        resource: {
+                            ...newResource,
+                            meta: {
+                                versionId: newVid.toString(),
+                                lastUpdated: expect.stringMatching(utcTimeRegExp),
+                                security: 'skynet',
+                            },
+                        },
                     },
                 ],
                 success: true,

--- a/src/dataServices/dynamoDbBundleServiceHelper.ts
+++ b/src/dataServices/dynamoDbBundleServiceHelper.ts
@@ -50,13 +50,11 @@ export default class DynamoDbBundleServiceHelper {
                             Item: DynamoDBConverter.marshall(Item),
                         },
                     });
-                    const { stagingResponse, itemLocked } = this.addStagingResponseAndItemsLocked(
+                    const { stagingResponse, itemLocked } = this.addStagingResponseAndItemsLocked(request.operation, {
+                        ...request.resource,
+                        meta: { ...Item.meta },
                         id,
-                        vid,
-                        request.resourceType,
-                        request.operation,
-                        Item.meta.lastUpdated,
-                    );
+                    });
                     newBundleEntryResponses = newBundleEntryResponses.concat(stagingResponse);
                     newLocks = newLocks.concat(itemLocked);
                     break;
@@ -75,13 +73,10 @@ export default class DynamoDbBundleServiceHelper {
                         },
                     });
 
-                    const { stagingResponse, itemLocked } = this.addStagingResponseAndItemsLocked(
-                        id,
-                        vid,
-                        request.resourceType,
-                        request.operation,
-                        Item.meta.lastUpdated,
-                    );
+                    const { stagingResponse, itemLocked } = this.addStagingResponseAndItemsLocked(request.operation, {
+                        ...request.resource,
+                        meta: { ...Item.meta },
+                    });
                     newBundleEntryResponses = newBundleEntryResponses.concat(stagingResponse);
                     newLocks = newLocks.concat(itemLocked);
                     break;
@@ -216,25 +211,19 @@ export default class DynamoDbBundleServiceHelper {
         return updatedStagingResponses;
     }
 
-    private static addStagingResponseAndItemsLocked(
-        id: string,
-        vid: number,
-        resourceType: string,
-        operation: TypeOperation,
-        lastModified: string,
-    ) {
-        const stagingResponse = {
-            id,
-            vid: vid.toString(),
+    private static addStagingResponseAndItemsLocked(operation: TypeOperation, resource: any) {
+        const stagingResponse: BatchReadWriteResponse = {
+            id: resource.id,
+            vid: resource.meta.versionId,
             operation,
-            lastModified,
-            resourceType,
-            resource: {},
+            lastModified: resource.meta.lastUpdated,
+            resourceType: resource.resourceType,
+            resource,
         };
         const itemLocked: ItemRequest = {
-            id,
-            vid,
-            resourceType,
+            id: resource.id,
+            vid: parseInt(resource.meta.versionId, 10),
+            resourceType: resource.resourceType,
             operation,
         };
         if (operation === 'update') {

--- a/testUtilities/GenerateStagingRequestsFactory.ts
+++ b/testUtilities/GenerateStagingRequestsFactory.ts
@@ -62,7 +62,11 @@ export default class GenerateStagingRequestsFactory {
             vid: '1',
             operation: 'create',
             resourceType: 'Patient',
-            resource: {},
+            resource: {
+                ...createResource,
+                id: expect.stringMatching(uuidRegExp),
+                meta: { versionId: '1', lastUpdated: expect.stringMatching(utcTimeRegExp) },
+            },
             lastModified: expect.stringMatching(utcTimeRegExp),
         };
         return {
@@ -124,6 +128,9 @@ export default class GenerateStagingRequestsFactory {
 
     static getUpdate(): RequestResult {
         const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
+        const vid = 1;
+        const nextVid = 2;
+        const existingMeta = { security: [{ code: 'test' }], versionId: vid.toString() };
         const resource = {
             resourceType: 'Patient',
             id,
@@ -134,6 +141,7 @@ export default class GenerateStagingRequestsFactory {
                 },
             ],
             gender: 'male',
+            meta: existingMeta,
         };
         const request: BatchReadWriteRequest = {
             operation: 'update',
@@ -142,9 +150,8 @@ export default class GenerateStagingRequestsFactory {
             resource,
             fullUrl: `urn:uuid:${id}`,
         };
-        const vid = 1;
-        const nextVid = 2;
-        const expectedUpdateItem: any = { ...resource };
+
+        const expectedUpdateItem: any = { ...resource, meta: { ...existingMeta, versionId: nextVid.toString() } };
         expectedUpdateItem[DOCUMENT_STATUS_FIELD] = DOCUMENT_STATUS.PENDING;
         expectedUpdateItem.id = id;
         expectedUpdateItem.vid = nextVid;
@@ -157,7 +164,7 @@ export default class GenerateStagingRequestsFactory {
         };
 
         const expectedLock: ItemRequest = {
-            id: expect.stringMatching(uuidRegExp),
+            id,
             vid: nextVid,
             resourceType: 'Patient',
             operation: 'update',
@@ -165,11 +172,18 @@ export default class GenerateStagingRequestsFactory {
         };
 
         const expectedStagingResponse: BatchReadWriteResponse = {
-            id: expect.stringMatching(uuidRegExp),
+            id,
             vid: nextVid.toString(),
             operation: 'update',
             resourceType: 'Patient',
-            resource: {},
+            resource: {
+                ...resource,
+                meta: {
+                    ...existingMeta,
+                    versionId: nextVid.toString(),
+                    lastUpdated: expect.stringMatching(utcTimeRegExp),
+                },
+            },
             lastModified: expect.stringMatching(utcTimeRegExp),
         };
 


### PR DESCRIPTION
Issue #, if available: #64

Description of changes:
- Update bundle processer to return the meta field created by the bundler
- This will fix a issue where we do not return the correctly stored information

Test cases:
- Create; with `security` in `meta`
- Update; adding `security` in `meta`
- Update; removing `security` in `meta`
- Bundle flow; creating and updating with `security` in `meta`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.