### PR TITLE
fix: improve error logging for ddbToEs sync

### DIFF
--- a/src/AWS.ts
+++ b/src/AWS.ts
@@ -12,13 +12,13 @@ const AWSWithXray = AWSXRay.captureAWS(AWS);
 const { IS_OFFLINE } = process.env;
 
 if (IS_OFFLINE === 'true') {
-    AWS.config.update({
+    AWSWithXray.config.update({
         region: process.env.AWS_REGION || 'us-west-2',
         accessKeyId: process.env.ACCESS_KEY,
         secretAccessKey: process.env.SECRET_KEY,
     });
 } else {
-    AWS.config.update({
+    AWSWithXray.config.update({
         customUserAgent: process.env.CUSTOM_USER_AGENT,
     });
 }

--- a/src/ddbToEs/ddbToEsHelper.ts
+++ b/src/ddbToEs/ddbToEsHelper.ts
@@ -72,7 +72,8 @@ export default class DdbToEsHelper {
                 await this.ElasticSearch.indices.create(params);
             }
         } catch (error) {
-            console.log('Failed to check if index exist or create index', error);
+            console.error(`Failed to check if index: ${indexName} exist or create index`);
+            throw error;
         }
     }
 
@@ -140,64 +141,58 @@ export default class DdbToEsHelper {
 
     // eslint-disable-next-line class-methods-use-this
     async logAndExecutePromises(promiseParamAndIds: PromiseParamAndId[]) {
-        const upsertAvailablePromiseParamAndIds = promiseParamAndIds.filter(paramAndId => {
-            return paramAndId.type === 'upsert-AVAILABLE';
-        });
-
-        const upsertDeletedPromiseParamAndIds = promiseParamAndIds.filter(paramAndId => {
-            return paramAndId.type === 'upsert-DELETED';
-        });
-
-        const deletePromiseParamAndIds = promiseParamAndIds.filter(paramAndId => {
-            return paramAndId.type === 'delete';
-        });
-
-        console.log(
-            `Operation: upsert-AVAILABLE on resource Ids `,
-            upsertAvailablePromiseParamAndIds.map(paramAndId => {
-                return paramAndId.id;
-            }),
-        );
-
         // We're using allSettled-shim because as of 7/21/2020 'serverless-plugin-typescript' does not support
         // Promise.allSettled.
         allSettled.shim();
 
-        // We need to execute creation of a resource before execute deleting of a resource,
-        // because a resource can be created and deleted, but not deleted then restored to AVAILABLE
-        // @ts-ignore
-        await Promise.allSettled(
-            upsertAvailablePromiseParamAndIds.map(paramAndId => {
-                return this.ElasticSearch.update(paramAndId.promiseParam);
-            }),
-        );
+        await this.executePromiseBlock('upsert-AVAILABLE', promiseParamAndIds);
+        await this.executePromiseBlock('upsert-DELETED', promiseParamAndIds);
+        await this.executePromiseBlock('delete', promiseParamAndIds);
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async executePromiseBlock(type: PromiseType, promiseParamAndIds: PromiseParamAndId[]) {
+        const filteredPromiseParamAndIds = promiseParamAndIds.filter(paramAndId => {
+            return paramAndId.type === type;
+        });
+
+        if (filteredPromiseParamAndIds.length === 0) {
+            return;
+        }
 
         console.log(
-            `Operation: upsert-DELETED on resource Ids `,
-            upsertDeletedPromiseParamAndIds.map(paramAndId => {
+            `Starting operation "${type}" on resource Ids: `,
+            filteredPromiseParamAndIds.map(paramAndId => {
                 return paramAndId.id;
             }),
         );
 
         // @ts-ignore
-        await Promise.allSettled(
-            upsertDeletedPromiseParamAndIds.map(paramAndId => {
-                return this.ElasticSearch.update(paramAndId.promiseParam);
+        const results = await Promise.allSettled(
+            filteredPromiseParamAndIds.map(async paramAndId => {
+                try {
+                    let response;
+                    if (type === 'upsert-AVAILABLE' || type === 'upsert-DELETED') {
+                        response = await this.ElasticSearch.update(paramAndId.promiseParam);
+                    } else if (type === 'delete') {
+                        response = await this.ElasticSearch.delete(paramAndId.promiseParam);
+                    } else {
+                        throw new Error(`unknown type: ${type}`);
+                    }
+                    return response;
+                } catch (e) {
+                    console.error(`${type} failed on id: ${paramAndId.id}, due to error:\n${e}`);
+                    throw e;
+                }
             }),
         );
 
-        console.log(
-            `Operation: delete on resource Ids `,
-            deletePromiseParamAndIds.map(paramAndId => {
-                return paramAndId.id;
-            }),
-        );
-
-        // @ts-ignore
-        await Promise.allSettled(
-            deletePromiseParamAndIds.map(paramAndId => {
-                return this.ElasticSearch.delete(paramAndId.promiseParam);
-            }),
-        );
+        // Throw rejected promises
+        const rejected = results
+            .filter((result: { status: string }) => result.status === 'rejected')
+            .map((result: { reason: string }) => result.reason);
+        if (rejected.length > 0) {
+            throw new Error(rejected);
+        }
     }
 }

--- a/src/ddbToEs/index.ts
+++ b/src/ddbToEs/index.ts
@@ -25,7 +25,6 @@ export async function handleDdbToEsEvent(event: any) {
             const image = AWS.DynamoDB.Converter.unmarshall(ddbJsonImage);
             // Don't index binary files
             if (ddbToEsHelper.isBinaryResource(image)) {
-                console.log('This is a Binary resource. These are not searchable');
                 // eslint-disable-next-line no-continue
                 continue;
             }
@@ -47,6 +46,20 @@ export async function handleDdbToEsEvent(event: any) {
 
         await ddbToEsHelper.logAndExecutePromises(promiseParamAndIds);
     } catch (e) {
-        console.log('Failed to update ES records', e);
+        console.error(
+            'Synchonization failed! The resources that could be effected are: ',
+            event.Records.map(
+                (record: {
+                    eventName: string;
+                    dynamodb: { OldImage: AWS.DynamoDB.AttributeMap; NewImage: AWS.DynamoDB.AttributeMap };
+                }) => {
+                    const image = record.eventName === REMOVE ? record.dynamodb.OldImage : record.dynamodb.NewImage;
+                    return `{id: ${image.id.S}, vid: ${image.vid.N}}`;
+                },
+            ),
+        );
+
+        console.error('Failed to update ES records', e);
+        throw e;
     }
 }

--- a/src/ddbToEs/index.ts
+++ b/src/ddbToEs/index.ts
@@ -47,7 +47,7 @@ export async function handleDdbToEsEvent(event: any) {
         await ddbToEsHelper.logAndExecutePromises(promiseParamAndIds);
     } catch (e) {
         console.error(
-            'Synchonization failed! The resources that could be effected are: ',
+            'Synchronization failed! The resources that could be effected are: ',
             event.Records.map(
                 (record: {
                     eventName: string;


### PR DESCRIPTION
Issue #, if available: #18, https://github.com/awslabs/fhir-works-on-aws-search-es/issues/21

The goal with this PR is:
1. throw an error if the lambda can't process (causing retries/failures)
2. if errors do occur put in the logs:
    1. the resources that were 'bad'
    2. all the resources in this batch that may not have been processed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.