### PR TITLE
feat!: expect elastic search instance to be passed in

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@elastic/elasticsearch": "^7.4",
     "@types/aws-lambda": "^8.10.63",
-    "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
     "aws-xray-sdk": "^3.1.0",
     "fhir-works-on-aws-interface": "^8.1.1",

--- a/src/ddbToEs/ddbToEsHelper.ts
+++ b/src/ddbToEs/ddbToEsHelper.ts
@@ -4,39 +4,18 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
-// @ts-ignore
-import { AmazonConnection, AmazonTransport } from 'aws-elasticsearch-connector';
 import allSettled from 'promise.allsettled';
-import AWS from '../AWS';
 import PromiseParamAndId, { PromiseType } from './promiseParamAndId';
 import { DOCUMENT_STATUS_FIELD } from '../dataServices/dynamoDbUtil';
 import DOCUMENT_STATUS from '../dataServices/documentStatus';
 
 const BINARY_RESOURCE = 'binary';
 
-const { IS_OFFLINE, ELASTICSEARCH_DOMAIN_ENDPOINT } = process.env;
-
 export default class DdbToEsHelper {
     private ElasticSearch: Client;
 
-    constructor() {
-        let ES_DOMAIN_ENDPOINT = ELASTICSEARCH_DOMAIN_ENDPOINT || 'https://fake-es-endpoint.com';
-        if (IS_OFFLINE === 'true') {
-            const { ACCESS_KEY, SECRET_KEY, AWS_REGION, OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT } = process.env;
-
-            AWS.config.update({
-                region: AWS_REGION || 'us-west-2',
-                accessKeyId: ACCESS_KEY,
-                secretAccessKey: SECRET_KEY,
-            });
-            ES_DOMAIN_ENDPOINT = OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT || 'https://fake-es-endpoint.com';
-        }
-
-        this.ElasticSearch = new Client({
-            node: ES_DOMAIN_ENDPOINT,
-            Connection: AmazonConnection,
-            Transport: AmazonTransport,
-        });
+    constructor(ElasticSearch: Client) {
+        this.ElasticSearch = ElasticSearch;
     }
 
     async createIndexIfNotExist(indexName: string) {

--- a/src/ddbToEs/index.ts
+++ b/src/ddbToEs/index.ts
@@ -4,6 +4,7 @@
  */
 
 import AWS from 'aws-sdk';
+import { Client } from '@elastic/elasticsearch';
 import DdbToEsHelper from './ddbToEsHelper';
 import PromiseParamAndId from './promiseParamAndId';
 
@@ -13,9 +14,9 @@ const REMOVE = 'REMOVE';
 // This lambda picks up changes from DDB by way of DDB stream, and sends those changes to ElasticSearch Service for indexing.
 // This allows the FHIR API Server to query ElasticSearch service for search requests
 
-export async function handleDdbToEsEvent(event: any) {
-    const ddbToEsHelper = new DdbToEsHelper();
+export async function handleDdbToEsEvent(event: any, ElasticSearch: Client) {
     try {
+        const ddbToEsHelper = new DdbToEsHelper(ElasticSearch);
         const promiseParamAndIds: PromiseParamAndId[] = [];
         for (let i = 0; i < event.Records.length; i += 1) {
             const record = event.Records[i];
@@ -25,7 +26,6 @@ export async function handleDdbToEsEvent(event: any) {
             const image = AWS.DynamoDB.Converter.unmarshall(ddbJsonImage);
             // Don't index binary files
             if (ddbToEsHelper.isBinaryResource(image)) {
-                console.log('This is a Binary resource. These are not searchable');
                 // eslint-disable-next-line no-continue
                 continue;
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,14 +1023,6 @@ atomic-batcher@^1.0.2:
   resolved "https://registry.yarnpkg.com/atomic-batcher/-/atomic-batcher-1.0.2.tgz#d16901d10ccec59516c197b9ccd8930689b813b4"
   integrity sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q=
 
-aws-elasticsearch-connector@^8.2.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/aws-elasticsearch-connector/-/aws-elasticsearch-connector-8.3.0.tgz#14637941ca1adcec878cc0f07ca02712f1e6736a"
-  integrity sha512-OPd1iNhebBBpGIvvjL79J5FcfdokD7LXbSeo6mENdWNqiIykYHnD5jT2wRFA4CSDpZBgEq9cUgc0D60GOxQp3A==
-  dependencies:
-    aws4 "^1.10.0"
-    lodash.get "^4.4.2"
-
 aws-sdk-mock@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-5.1.0.tgz#6f2c0bd670d7f378c906a8dd806f812124db71aa"
@@ -1103,7 +1095,7 @@ aws-xray-sdk@^3.1.0:
     aws-xray-sdk-postgres "3.2.0"
     pkginfo "^0.4.0"
 
-aws4@^1.10.0, aws4@^1.8.0:
+aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==


### PR DESCRIPTION
BREAKING CHANGE

Description of changes:
- Following the AWS best practice:
> AWS service clients should be instantiated in the initialization code, not in the handler. This allows AWS Lambda to reuse existing connections, for the duration of the container's lifetime.
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.BestPracticesWithDynamoDB.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.