### PR TITLE
fix: initialize ES client only once

### DIFF
--- a/src/ddbToEs/index.ts
+++ b/src/ddbToEs/index.ts
@@ -10,13 +10,13 @@ import getComponentLogger from '../loggerBuilder';
 
 const REMOVE = 'REMOVE';
 const logger = getComponentLogger();
+const ddbToEsHelper = new DdbToEsHelper();
 
 // This is a separate lambda function from the main FHIR API server lambda.
 // This lambda picks up changes from DDB by way of DDB stream, and sends those changes to ElasticSearch Service for indexing.
 // This allows the FHIR API Server to query ElasticSearch service for search requests
 
 export async function handleDdbToEsEvent(event: any) {
-    const ddbToEsHelper = new DdbToEsHelper();
     try {
         const promiseParamAndIds: PromiseParamAndId[] = [];
         for (let i = 0; i < event.Records.length; i += 1) {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* The root cause of this issue is the connections used for ES being held up in cache after Lambda function done running. And the sockets used for the connection takes up the file descriptors allocated to the Lambda function. Lambda function has a hard limit for number of file descriptors it can use: https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html 
* The solution here is to initialize the ES client only once for the container. This way cached connections can be reused, and only a constant number of file descriptors(~450) are needed. 
* The change is load tested and esToDDB Lambda can sync the data consistently when hitting FHIR server at 45 TPS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.