### PR TITLE
feat: support update as create in bundle service

### DIFF
--- a/src/dataServices/dynamoDbBundleService.test.ts
+++ b/src/dataServices/dynamoDbBundleService.test.ts
@@ -8,7 +8,7 @@ import * as AWSMock from 'aws-sdk-mock';
 
 import { QueryInput, TransactWriteItemsInput } from 'aws-sdk/clients/dynamodb';
 import AWS from 'aws-sdk';
-import { BundleResponse, BatchReadWriteRequest } from 'fhir-works-on-aws-interface';
+import { BundleResponse, BatchReadWriteRequest, TypeOperation } from 'fhir-works-on-aws-interface';
 import { DynamoDbBundleService } from './dynamoDbBundleService';
 import { DynamoDBConverter } from './dynamoDb';
 import { timeFromEpochInMsRegExp, utcTimeRegExp, uuidRegExp } from '../../testUtilities/regExpressions';
@@ -449,5 +449,56 @@ describe('atomicallyReadWriteResources', () => {
         test('UPDATING a resource with references', async () => {
             await runUpdateTest(true);
         });
+    });
+
+    describe('Update as Create Cases', () => {
+        const runTest = async (supportUpdateCreate: boolean, operation: TypeOperation, isLockSuccessful: boolean) => {
+            // READ items (Failure)
+            AWSMock.mock('DynamoDB', 'query', (params: QueryInput, callback: Function) => {
+                callback(null, { Items: [] });
+            });
+
+            const dynamoDb = new AWS.DynamoDB();
+            const bundleService = new DynamoDbBundleService(dynamoDb, supportUpdateCreate);
+
+            const updateRequest: BatchReadWriteRequest = {
+                operation,
+                resourceType: 'Patient',
+                id,
+                resource: 'Patient/bce8411e-c15e-448c-95dd-69155a837405',
+            };
+            // @ts-ignore
+            const actualResponse = await bundleService.lockItems([updateRequest]);
+            if (isLockSuccessful) {
+                expect(actualResponse).toStrictEqual({
+                    lockedItems: [],
+                    successfulLock: true,
+                });
+            } else {
+                expect(actualResponse).toStrictEqual({
+                    errorMessage: 'Failed to find resources: Patient/bce8411e-c15e-448c-95dd-69155a837405',
+                    errorType: 'USER_ERROR',
+                    lockedItems: [],
+                    successfulLock: false,
+                });
+            }
+        };
+
+        const testCases = [
+            // ['supportUpdateCreate', 'operation', 'isLockSuccessful'],
+            [true, 'create', true],
+            [true, 'update', true],
+            [true, 'read', false],
+            [false, 'create', true],
+            [false, 'update', false],
+            [false, 'read', false],
+        ];
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const [supportUpdateCreate, operation, isLockSuccessful] of testCases) {
+            test('lock update ', async () => {
+                await runTest(supportUpdateCreate as boolean, operation as TypeOperation, isLockSuccessful as boolean);
+            });
+        }
     });
 });

--- a/src/dataServices/dynamoDbBundleService.test.ts
+++ b/src/dataServices/dynamoDbBundleService.test.ts
@@ -461,14 +461,14 @@ describe('atomicallyReadWriteResources', () => {
             const dynamoDb = new AWS.DynamoDB();
             const bundleService = new DynamoDbBundleService(dynamoDb, supportUpdateCreate);
 
-            const updateRequest: BatchReadWriteRequest = {
+            const batchRequest: BatchReadWriteRequest = {
                 operation,
                 resourceType: 'Patient',
                 id,
-                resource: 'Patient/bce8411e-c15e-448c-95dd-69155a837405',
+                resource: `Patient/${id}`,
             };
             // @ts-ignore
-            const actualResponse = await bundleService.lockItems([updateRequest]);
+            const actualResponse = await bundleService.lockItems([batchRequest]);
             if (isLockSuccessful) {
                 expect(actualResponse).toStrictEqual({
                     lockedItems: [],
@@ -476,7 +476,7 @@ describe('atomicallyReadWriteResources', () => {
                 });
             } else {
                 expect(actualResponse).toStrictEqual({
-                    errorMessage: 'Failed to find resources: Patient/bce8411e-c15e-448c-95dd-69155a837405',
+                    errorMessage: `Failed to find resources: Patient/${id}`,
                     errorType: 'USER_ERROR',
                     lockedItems: [],
                     successfulLock: false,

--- a/src/dataServices/dynamoDbBundleService.ts
+++ b/src/dataServices/dynamoDbBundleService.ts
@@ -190,7 +190,8 @@ export class DynamoDbBundleService implements Bundle {
         const idItemsFailedToRead: string[] = [];
         for (let i = 0; i < itemResponses.length; i += 1) {
             const itemResponse = itemResponses[i];
-            if (itemResponse instanceof ResourceNotFoundError) {
+            // allow for update as create scenario
+            if (itemResponse instanceof ResourceNotFoundError && itemsToLock[i].operation !== 'update') {
                 idItemsFailedToRead.push(`${itemsToLock[i].resourceType}/${itemsToLock[i].id}`);
             }
         }

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -70,7 +70,7 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
 
     constructor(dynamoDb: DynamoDB, supportUpdateCreate: boolean = false) {
         this.dynamoDbHelper = new DynamoDbHelper(dynamoDb);
-        this.transactionService = new DynamoDbBundleService(dynamoDb);
+        this.transactionService = new DynamoDbBundleService(dynamoDb, supportUpdateCreate);
         this.dynamoDb = dynamoDb;
         this.updateCreateSupported = supportUpdateCreate;
     }


### PR DESCRIPTION
Description of changes:
In order to lock resources for operations other than 'create' the latest version ID needs to be looked up first.  
If the resource isn't found a ResourceNotFoundError is thrown. 
With this change only ResourceNotFoundErrors for operations other than 'update' are being counted and result in a failed transaction.
By allowing 'update' operation for resources that don't exist in dynamo yet using update as create is possible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.