### PR TITLE
feat: tenant isolation for DDB CRUD operations

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,4 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 export const SEPARATOR: string = '_';
+export const DDB_HASH_KEY_SEPARATOR: string = '|';

--- a/src/dataServices/dynamoDbHelper.ts
+++ b/src/dataServices/dynamoDbHelper.ts
@@ -22,12 +22,14 @@ export default class DynamoDbHelper {
         id: string,
         maxNumberOfVersionsToGet: number,
         projectionExpression?: string,
+        tenantId?: string,
     ): Promise<ItemList> {
         const params = DynamoDbParamBuilder.buildGetResourcesQueryParam(
             id,
             resourceType,
             maxNumberOfVersionsToGet,
             projectionExpression,
+            tenantId,
         );
         let result: any = {};
         try {
@@ -52,8 +54,9 @@ export default class DynamoDbHelper {
         resourceType: string,
         id: string,
         projectionExpression?: string,
+        tenantId?: string,
     ): Promise<GenericResponse> {
-        let item = (await this.getMostRecentResources(resourceType, id, 1, projectionExpression))[0];
+        let item = (await this.getMostRecentResources(resourceType, id, 1, projectionExpression, tenantId))[0];
         item = DynamoDbUtil.cleanItem(item);
 
         return {
@@ -65,8 +68,12 @@ export default class DynamoDbHelper {
     /**
      * @return The most recent resource that has not been deleted and has been committed to the database (i.e. The resource is not in a transitional state)
      */
-    async getMostRecentUserReadableResource(resourceType: string, id: string): Promise<GenericResponse> {
-        const items = await this.getMostRecentResources(resourceType, id, 2);
+    async getMostRecentUserReadableResource(
+        resourceType: string,
+        id: string,
+        tenantId?: string,
+    ): Promise<GenericResponse> {
+        const items = await this.getMostRecentResources(resourceType, id, 2, undefined, tenantId);
         const latestItemDocStatus: DOCUMENT_STATUS = <DOCUMENT_STATUS>items[0][DOCUMENT_STATUS_FIELD];
         if (latestItemDocStatus === DOCUMENT_STATUS.DELETED) {
             throw new ResourceNotFoundError(resourceType, id);

--- a/src/dataServices/dynamoDbParamBuilder.test.ts
+++ b/src/dataServices/dynamoDbParamBuilder.test.ts
@@ -147,6 +147,28 @@ describe('buildUpdateDocumentStatusParam', () => {
         expect(futureTs).toBeGreaterThanOrEqual(currentTs - wiggleRoomInMs);
         expect(actualParam).toEqual(getExpectedParamForUpdateWithoutOldStatus(DOCUMENT_STATUS.AVAILABLE, id, vid));
     });
+
+    test('tenantId present', () => {
+        const id = '8cafa46d-08b4-4ee4-b51b-803e20ae8126';
+        const vid = 1;
+        const actualParam = DynamoDbParamBuilder.buildUpdateDocumentStatusParam(
+            null,
+            DOCUMENT_STATUS.AVAILABLE,
+            id,
+            vid,
+            resourceType,
+            'tenant1',
+        );
+        const expected = getExpectedParamForUpdateWithoutOldStatus(DOCUMENT_STATUS.AVAILABLE, id, vid);
+        expected.Update.Key = {
+            ...expected.Update.Key,
+            id: {
+                S: 'tenant1|8cafa46d-08b4-4ee4-b51b-803e20ae8126',
+            },
+        };
+
+        expect(actualParam).toEqual(expected);
+    });
 });
 
 describe('buildPutAvailableItemParam', () => {
@@ -235,6 +257,26 @@ describe('buildPutAvailableItemParam', () => {
 
         expect(actualParams).toEqual(clonedExpectedParams);
     });
+
+    test('tenantId present', () => {
+        const actualParams = DynamoDbParamBuilder.buildPutAvailableItemParam(item, id, vid, false, 'tenant1');
+
+        const clonedExpectedParams = cloneDeep(expectedParams);
+        clonedExpectedParams.Item = {
+            ...clonedExpectedParams.Item,
+            _tenantId: {
+                S: 'tenant1',
+            },
+            _id: {
+                S: '8cafa46d-08b4-4ee4-b51b-803e20ae8126',
+            },
+            id: {
+                S: 'tenant1|8cafa46d-08b4-4ee4-b51b-803e20ae8126',
+            },
+        };
+
+        expect(actualParams).toEqual(clonedExpectedParams);
+    });
 });
 
 describe('buildGetResourcesQueryParam', () => {
@@ -262,6 +304,20 @@ describe('buildGetResourcesQueryParam', () => {
 
         const clonedExpectedParam: any = cloneDeep(expectedParam);
         clonedExpectedParam.ProjectionExpression = projectionExpression;
+
+        expect(actualParam).toEqual(clonedExpectedParam);
+    });
+
+    test('tenantId present', () => {
+        const actualParam = DynamoDbParamBuilder.buildGetResourcesQueryParam(id, 'Patient', 2, undefined, 'tenant1');
+
+        const clonedExpectedParam: any = cloneDeep(expectedParam);
+        clonedExpectedParam.ExpressionAttributeValues = {
+            ...clonedExpectedParam.ExpressionAttributeValues,
+            ':hkey': {
+                S: 'tenant1|8cafa46d-08b4-4ee4-b51b-803e20ae8126',
+            },
+        };
 
         expect(actualParam).toEqual(clonedExpectedParam);
     });

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -6,11 +6,11 @@
 import { ExportJobStatus } from 'fhir-works-on-aws-interface';
 import {
     DynamoDBConverter,
-    RESOURCE_TABLE,
     EXPORT_REQUEST_TABLE,
     EXPORT_REQUEST_TABLE_JOB_STATUS_INDEX,
+    RESOURCE_TABLE,
 } from './dynamoDb';
-import { DynamoDbUtil, DOCUMENT_STATUS_FIELD, LOCK_END_TS_FIELD } from './dynamoDbUtil';
+import { buildHashKey, DOCUMENT_STATUS_FIELD, DynamoDbUtil, LOCK_END_TS_FIELD } from './dynamoDbUtil';
 import DOCUMENT_STATUS from './documentStatus';
 import { BulkExportJob } from '../bulkExport/types';
 
@@ -23,6 +23,7 @@ export default class DynamoDbParamBuilder {
         id: string,
         vid: number,
         resourceType: string,
+        tenantId?: string,
     ) {
         const currentTs = Date.now();
         let futureEndTs = currentTs;
@@ -34,7 +35,7 @@ export default class DynamoDbParamBuilder {
             Update: {
                 TableName: RESOURCE_TABLE,
                 Key: DynamoDBConverter.marshall({
-                    id,
+                    id: buildHashKey(id, tenantId),
                     vid,
                 }),
                 UpdateExpression: `set ${DOCUMENT_STATUS_FIELD} = :newStatus, ${LOCK_END_TS_FIELD} = :futureEndTs`,
@@ -69,6 +70,7 @@ export default class DynamoDbParamBuilder {
         resourceType: string,
         maxNumberOfVersions: number,
         projectionExpression?: string,
+        tenantId?: string,
     ) {
         const params: any = {
             TableName: RESOURCE_TABLE,
@@ -78,7 +80,7 @@ export default class DynamoDbParamBuilder {
             KeyConditionExpression: 'id = :hkey',
             ExpressionAttributeNames: { '#r': 'resourceType' },
             ExpressionAttributeValues: DynamoDBConverter.marshall({
-                ':hkey': id,
+                ':hkey': buildHashKey(id, tenantId),
                 ':resourceType': resourceType,
             }),
         };
@@ -90,12 +92,12 @@ export default class DynamoDbParamBuilder {
         return params;
     }
 
-    static buildDeleteParam(id: string, vid: number) {
+    static buildDeleteParam(id: string, vid: number, tenantId?: string) {
         const params: any = {
             Delete: {
                 TableName: RESOURCE_TABLE,
                 Key: DynamoDBConverter.marshall({
-                    id,
+                    id: buildHashKey(id, tenantId),
                     vid,
                 }),
             },
@@ -104,11 +106,11 @@ export default class DynamoDbParamBuilder {
         return params;
     }
 
-    static buildGetItemParam(id: string, vid: number) {
+    static buildGetItemParam(id: string, vid: number, tenantId?: string) {
         return {
             TableName: RESOURCE_TABLE,
             Key: DynamoDBConverter.marshall({
-                id,
+                id: buildHashKey(id, tenantId),
                 vid,
             }),
         };
@@ -120,8 +122,14 @@ export default class DynamoDbParamBuilder {
      * @param allowOverwriteId - Allow overwriting a resource with the same id
      * @return DDB params for PUT operation
      */
-    static buildPutAvailableItemParam(item: any, id: string, vid: number, allowOverwriteId: boolean = false) {
-        const newItem = DynamoDbUtil.prepItemForDdbInsert(item, id, vid, DOCUMENT_STATUS.AVAILABLE);
+    static buildPutAvailableItemParam(
+        item: any,
+        id: string,
+        vid: number,
+        allowOverwriteId: boolean = false,
+        tenantId?: string,
+    ) {
+        const newItem = DynamoDbUtil.prepItemForDdbInsert(item, id, vid, DOCUMENT_STATUS.AVAILABLE, tenantId);
         const param: any = {
             TableName: RESOURCE_TABLE,
             Item: DynamoDBConverter.marshall(newItem),

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -5,13 +5,22 @@
 
 import { clone, generateMeta } from 'fhir-works-on-aws-interface';
 import flatten from 'flat';
-import { SEPARATOR } from '../constants';
+import { DDB_HASH_KEY_SEPARATOR, SEPARATOR } from '../constants';
 import DOCUMENT_STATUS from './documentStatus';
 
 export const DOCUMENT_STATUS_FIELD = 'documentStatus';
 export const LOCK_END_TS_FIELD = 'lockEndTs';
 export const VID_FIELD = 'vid';
 export const REFERENCES_FIELD = '_references';
+export const TENANT_ID_FIELD = '_tenantId';
+export const INTERNAL_ID_FIELD = '_id';
+
+export const buildHashKey = (id: string, tenantId?: string): string => {
+    if (tenantId !== undefined) {
+        return `${tenantId}|${id}`;
+    }
+    return id;
+};
 
 export class DynamoDbUtil {
     static cleanItem(item: any) {
@@ -26,12 +35,30 @@ export class DynamoDbUtil {
         const id = item.id.split(SEPARATOR)[0];
         cleanedItem.id = id;
 
+        if (cleanedItem.id.includes(DDB_HASH_KEY_SEPARATOR)) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const [tenantId, resourceId] = cleanedItem.id.split(DDB_HASH_KEY_SEPARATOR);
+            if (resourceId === undefined) {
+                throw new Error(`Invalid schema for resource Id: ${cleanedItem.id}`);
+            }
+            cleanedItem.id = resourceId;
+        }
+
+        delete cleanedItem[TENANT_ID_FIELD];
+        delete cleanedItem[INTERNAL_ID_FIELD];
+
         return cleanedItem;
     }
 
-    static prepItemForDdbInsert(resource: any, id: string, vid: number, documentStatus: DOCUMENT_STATUS) {
+    static prepItemForDdbInsert(
+        resource: any,
+        id: string,
+        vid: number,
+        documentStatus: DOCUMENT_STATUS,
+        tenantId?: string,
+    ) {
         const item = clone(resource);
-        item.id = id;
+        item.id = buildHashKey(id, tenantId);
         item.vid = vid;
 
         // versionId and lastUpdated for meta object should be system generated
@@ -44,6 +71,11 @@ export class DynamoDbUtil {
 
         item[DOCUMENT_STATUS_FIELD] = documentStatus;
         item[LOCK_END_TS_FIELD] = Date.now();
+
+        if (tenantId !== undefined) {
+            item[TENANT_ID_FIELD] = tenantId;
+            item[INTERNAL_ID_FIELD] = id;
+        }
 
         // Format of flattenedResource
         // https://www.npmjs.com/package/flat

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -16,7 +16,7 @@ export const TENANT_ID_FIELD = '_tenantId';
 export const INTERNAL_ID_FIELD = '_id';
 
 export const buildHashKey = (id: string, tenantId?: string): string => {
-    if (tenantId !== undefined) {
+    if (tenantId) {
         return `${tenantId}|${id}`;
     }
     return id;
@@ -72,7 +72,7 @@ export class DynamoDbUtil {
         item[DOCUMENT_STATUS_FIELD] = documentStatus;
         item[LOCK_END_TS_FIELD] = Date.now();
 
-        if (tenantId !== undefined) {
+        if (tenantId) {
             item[TENANT_ID_FIELD] = tenantId;
             item[INTERNAL_ID_FIELD] = id;
         }


### PR DESCRIPTION
Use tenantId as part of the hash key for all interactions with DDB.

The main changes are in `src/dataServices/dynamoDbUtil.ts` and `src/dataServices/dynamoDbParamBuilder.ts`. everything else is mostly just passing the tenantId around.

An example DDB record with multitenancy enabled would be:
```json
{
    "id": "tenant1|id1",
    "vid": 1,
    "_id": "id1",
    "_tenantId": "tenant1",
    "resourceType": "Patient",
    "birthDate": "1990-01-01"
    ...
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.