### PR TITLE
fix: list bulk export files with tenant prefix

### DIFF
--- a/src/bulkExport/bulkExport.test.ts
+++ b/src/bulkExport/bulkExport.test.ts
@@ -38,6 +38,19 @@ describe('getBulkExportResults', () => {
         ]);
     });
 
+    test('happy case with tenantId', async () => {
+        AWSMock.mock('S3', 'listObjectsV2', (params: any, callback: Function) => {
+            callback(null, {
+                Contents: [{ Key: 'tenant1/job-1/Patient-1.ndjson' }, { Key: 'tenant1/job-1/Observation-1.ndjson' }],
+            });
+        });
+
+        await expect(getBulkExportResults('job-1', 'tenant1')).resolves.toEqual([
+            { type: 'Patient', url: 'https://somePresignedUrl' },
+            { type: 'Observation', url: 'https://somePresignedUrl' },
+        ]);
+    });
+
     test('no results', async () => {
         AWSMock.mock('S3', 'listObjectsV2', (params: any, callback: Function) => {
             callback(null, {

--- a/src/bulkExport/bulkExport.test.ts
+++ b/src/bulkExport/bulkExport.test.ts
@@ -40,6 +40,7 @@ describe('getBulkExportResults', () => {
 
     test('happy case with tenantId', async () => {
         AWSMock.mock('S3', 'listObjectsV2', (params: any, callback: Function) => {
+            expect(params.Prefix).toEqual('tenant1/job-1');
             callback(null, {
                 Contents: [{ Key: 'tenant1/job-1/Patient-1.ndjson' }, { Key: 'tenant1/job-1/Observation-1.ndjson' }],
             });

--- a/src/bulkExport/bulkExport.ts
+++ b/src/bulkExport/bulkExport.ts
@@ -10,10 +10,10 @@ const EXPORT_RESULTS_BUCKET = process.env.EXPORT_RESULTS_BUCKET || ' ';
 const EXPORT_RESULTS_SIGNER_ROLE_ARN = process.env.EXPORT_RESULTS_SIGNER_ROLE_ARN || '';
 const EXPORT_STATE_MACHINE_ARN = process.env.EXPORT_STATE_MACHINE_ARN || '';
 
-const getFiles = async (jobId: string): Promise<string[]> => {
+const getFiles = async (prefix: string): Promise<string[]> => {
     const s3 = new AWS.S3();
 
-    const listObjectsResult = await s3.listObjectsV2({ Bucket: EXPORT_RESULTS_BUCKET, Prefix: jobId }).promise();
+    const listObjectsResult = await s3.listObjectsV2({ Bucket: EXPORT_RESULTS_BUCKET, Prefix: prefix }).promise();
     return listObjectsResult.Contents!.map(x => x.Key!);
 };
 
@@ -50,8 +50,8 @@ const signExportResults = async (keys: string[]): Promise<{ key: string; url: st
     );
 };
 
-const getResourceType = (key: string, jobId: string): string => {
-    const regex = new RegExp(`^${jobId}/([A-Za-z]+)-\\d+.ndjson$`);
+const getResourceType = (key: string, prefix: string): string => {
+    const regex = new RegExp(`^${prefix}/([A-Za-z]+)-\\d+.ndjson$`);
     const match = regex.exec(key);
     if (match === null) {
         throw new Error(`Could not parse the name of bulk exports result file: ${key}`);
@@ -59,11 +59,15 @@ const getResourceType = (key: string, jobId: string): string => {
     return match[1];
 };
 
-export const getBulkExportResults = async (jobId: string): Promise<{ type: string; url: string }[]> => {
-    const keys = await getFiles(jobId);
+export const getBulkExportResults = async (
+    jobId: string,
+    tenantId?: string,
+): Promise<{ type: string; url: string }[]> => {
+    const prefix = tenantId ? `${tenantId}/${jobId}` : jobId;
+    const keys = await getFiles(prefix);
     const signedUrls = await signExportResults(keys);
     return signedUrls.map(({ key, url }) => ({
-        type: getResourceType(key, jobId),
+        type: getResourceType(key, prefix),
         url,
     }));
 };

--- a/src/dataServices/dynamoDbDataService.ts
+++ b/src/dataServices/dynamoDbDataService.ts
@@ -304,7 +304,7 @@ export class DynamoDbDataService implements Persistence, BulkDataAccess {
             errorMessage = '',
         } = item;
 
-        const exportedFileUrls = jobStatus === 'completed' ? await getBulkExportResults(jobId) : [];
+        const exportedFileUrls = jobStatus === 'completed' ? await getBulkExportResults(jobId, tenantId) : [];
 
         const getExportStatusResponse: GetExportStatusResponse = {
             jobOwnerId,


### PR DESCRIPTION
Export results list was empty since the `tenantId` was not being used as prefix in calls to `s3.listObjects`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.