### PR TITLE
feat: persistence change for group export

### DIFF
--- a/src/bulkExport/bulkExport.ts
+++ b/src/bulkExport/bulkExport.ts
@@ -73,7 +73,18 @@ export const getBulkExportResults = async (
 };
 
 export const startJobExecution = async (bulkExportJob: BulkExportJob): Promise<void> => {
-    const { jobId, exportType, groupId, type, transactionTime, outputFormat, since, tenantId } = bulkExportJob;
+    const {
+        jobId,
+        exportType,
+        groupId,
+        type,
+        transactionTime,
+        outputFormat,
+        since,
+        tenantId,
+        serverUrl,
+        compartmentSearchParamFile,
+    } = bulkExportJob;
     const params: any = {
         jobId,
         exportType,
@@ -83,6 +94,8 @@ export const startJobExecution = async (bulkExportJob: BulkExportJob): Promise<v
     };
     if (groupId) {
         params.groupId = groupId;
+        params.serverUrl = serverUrl;
+        params.compartmentSearchParamFile = compartmentSearchParamFile;
     }
     if (type) {
         params.type = type;

--- a/src/bulkExport/startExportJob.ts
+++ b/src/bulkExport/startExportJob.ts
@@ -29,6 +29,8 @@ export const startExportJobHandler: Handler<
                 '--type': event.type!,
                 '--outputFormat': event.outputFormat!,
                 '--tenantId': event.tenantId!,
+                '--serverUrl': event.serverUrl!,
+                '--compartmentSearchParamFile': event.compartmentSearchParamFile!,
             },
         })
         .promise();

--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -27,6 +27,8 @@ export interface BulkExportStateMachineGlobalParameters {
     since?: string;
     type?: string;
     tenantId?: string;
+    serverUrl?: string;
+    compartmentSearchParamFile?: string;
     executionParameters?: BulkExportStateMachineExecutionParameters;
 }
 
@@ -42,4 +44,6 @@ export interface BulkExportJob {
     jobFailedMessage?: string;
     type?: string;
     tenantId?: string;
+    serverUrl?: string;
+    compartmentSearchParamFile?: string;
 }

--- a/src/dataServices/dynamoDbParamBuilder.test.ts
+++ b/src/dataServices/dynamoDbParamBuilder.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { cloneDeep } from 'lodash';
+import { InitiateExportRequest } from 'fhir-works-on-aws-interface';
 import DynamoDbParamBuilder from './dynamoDbParamBuilder';
 import DOCUMENT_STATUS from './documentStatus';
 import { timeFromEpochInMsRegExp, utcTimeRegExp } from '../../testUtilities/regExpressions';
@@ -339,6 +340,15 @@ describe('buildPutCreateExportRequest', () => {
         transactionTime,
         outputFormat,
         since,
+        type: 'Patient,DocumentReference',
+    };
+
+    const initiateExportRequest: InitiateExportRequest = {
+        allowedResourceTypes: ['Patient'],
+        exportType: 'system',
+        requesterUserId: 'fakeUserId',
+        transactionTime,
+        type: 'Patient',
     };
 
     const jobWithTenantId: BulkExportJob = {
@@ -370,16 +380,19 @@ describe('buildPutCreateExportRequest', () => {
             transactionTime: {
                 S: '2020-10-10T00:00:00.000Z',
             },
+            type: {
+                S: 'Patient',
+            },
         },
     };
     test('Job without tenantId', () => {
-        const actualParam = DynamoDbParamBuilder.buildPutCreateExportRequest(job);
+        const actualParam = DynamoDbParamBuilder.buildPutCreateExportRequest(job, initiateExportRequest);
         console.log(actualParam);
         expect(actualParam).toEqual(expectedParam);
     });
 
     test('tenantId present', () => {
-        const actualParam = DynamoDbParamBuilder.buildPutCreateExportRequest(jobWithTenantId);
+        const actualParam = DynamoDbParamBuilder.buildPutCreateExportRequest(jobWithTenantId, initiateExportRequest);
 
         const clonedExpectedParam: any = cloneDeep(expectedParam);
         clonedExpectedParam.Item = {

--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -3,7 +3,8 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExportJobStatus } from 'fhir-works-on-aws-interface';
+import { ExportJobStatus, InitiateExportRequest } from 'fhir-works-on-aws-interface';
+import { FhirVersion } from 'fhir-works-on-aws-interface/src/constants';
 import {
     DynamoDBConverter,
     EXPORT_REQUEST_TABLE,
@@ -143,12 +144,18 @@ export default class DynamoDbParamBuilder {
         return param;
     }
 
-    static buildPutCreateExportRequest(bulkExportJob: BulkExportJob) {
+    static buildPutCreateExportRequest(bulkExportJob: BulkExportJob, initiateExportRequest: InitiateExportRequest) {
         const newItem: any = { ...bulkExportJob };
         if (newItem.tenantId) {
             newItem[EXPORT_INTERNAL_ID_FIELD] = newItem.jobId;
             newItem.jobId = buildHashKey(newItem.jobId, newItem.tenantId);
         }
+        // Remove fields not needed
+        delete newItem.serverUrl;
+        delete newItem.fhirVersion;
+        delete newItem.allowedResourceTypes;
+        // Set type back to user input value
+        newItem.type = initiateExportRequest.type ?? '';
         return {
             TableName: EXPORT_REQUEST_TABLE,
             Item: DynamoDBConverter.marshall(newItem),


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Update to persistence to pass in parameters needed for group export
* Reject request if user ask for resource type outside of allowed types
* Clean up export request before saving to DDB
* Unit test 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.