### PR TITLE
feat: enable hard delete in Elasticsearch

### DIFF
--- a/src/ddbToEs/ddbToEsHelper.test.ts
+++ b/src/ddbToEs/ddbToEsHelper.test.ts
@@ -2,6 +2,7 @@ import { Client } from '@elastic/elasticsearch';
 
 import Mock from '@elastic/elasticsearch-mock';
 
+import cloneDeep from 'lodash';
 import DdbToEsHelper from './ddbToEsHelper';
 
 const ddbToEsHelper = new DdbToEsHelper();
@@ -21,6 +22,7 @@ describe('DdbToEsHelper', () => {
 
     describe('createIndexIfNotExist', () => {
         test('Create index and alias for new index', async () => {
+            process.env.ENABLE_ES_HARD_DELETE = 'true';
             // BUILD
             // esMock throws 404 for unmocked method, so there's no need to mock HEAD /patient here
             const mockAddIndex = jest.fn(() => {
@@ -86,6 +88,45 @@ describe('DdbToEsHelper', () => {
             expect(mockAddAlias).toHaveBeenCalledWith(
                 expect.objectContaining({ path: '/patient/_alias/patient-alias' }),
             );
+        });
+    });
+
+    describe('isRemoveResource', () => {
+        const record: any = {
+            eventID: 'some-event-id',
+            eventName: 'INSERT',
+            dynamodb: {
+                OldImage: { documentStatus: { S: 'AVAILABLE' } },
+                NewImage: { documentStatus: { S: 'AVAILABLE' } },
+            },
+        };
+
+        test('Should remove for REMOVE event', () => {
+            const removeRecord: any = cloneDeep(record);
+            removeRecord.eventName = 'REMOVE';
+            expect(ddbToEsHelper.isRemoveResource(removeRecord)).toBeTruthy();
+        });
+
+        test('Should remove for new image in DELETED status and hard delete enabled', () => {
+            process.env.ENABLE_ES_HARD_DELETE = 'true';
+            const modifyRecord: any = cloneDeep(record);
+            modifyRecord.eventName = 'MODIFY';
+            modifyRecord.dynamodb = {
+                OldImage: { documentStatus: { S: 'AVAILABLE' } },
+                NewImage: { documentStatus: { S: 'DELETED' } },
+            };
+            expect(ddbToEsHelper.isRemoveResource(modifyRecord)).toBeTruthy();
+        });
+
+        test('Should NOT remove for new image in DELETED status and hard delete NOT enabled', () => {
+            process.env.ENABLE_ES_HARD_DELETE = 'false';
+            const modifyRecord: any = cloneDeep(record);
+            modifyRecord.eventName = 'MODIFY';
+            modifyRecord.dynamodb = {
+                OldImage: { documentStatus: { S: 'AVAILABLE' } },
+                NewImage: { documentStatus: { S: 'DELETED' } },
+            };
+            expect(ddbToEsHelper.isRemoveResource(modifyRecord)).toBeFalsy();
         });
     });
 });

--- a/src/ddbToEs/ddbToEsHelper.ts
+++ b/src/ddbToEs/ddbToEsHelper.ts
@@ -13,6 +13,10 @@ import { DOCUMENT_STATUS_FIELD } from '../dataServices/dynamoDbUtil';
 import DOCUMENT_STATUS from '../dataServices/documentStatus';
 import getComponentLogger from '../loggerBuilder';
 
+const REMOVE = 'REMOVE';
+const DELETED = 'DELETED';
+const { ENABLE_ES_HARD_DELETE } = process.env;
+
 const logger = getComponentLogger();
 
 const BINARY_RESOURCE = 'binary';
@@ -183,6 +187,14 @@ export default class DdbToEsHelper {
         const resourceType = image.resourceType.toLowerCase();
         // Don't index binary files
         return resourceType === BINARY_RESOURCE;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    isRemoveResource(record: any): boolean {
+        if (record.eventName === REMOVE) {
+            return true;
+        }
+        return record.dynamodb.NewImage.documentStatus.S === DELETED && process.env.ENABLE_ES_HARD_DELETE === 'true';
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Enable hard delete for ES when DDB record is soft deleted 
* Tested deleted record is removed from ES through Kibana 
* Related Deployment change: https://github.com/awslabs/fhir-works-on-aws-deployment/pull/398 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.