### PR TITLE
fix: bulk export return the correct content-type

### DIFF
--- a/src/bulkExport/bulkExport.ts
+++ b/src/bulkExport/bulkExport.ts
@@ -6,6 +6,7 @@ import AWS from '../AWS';
 import { BulkExportJob } from './types';
 
 const EXPIRATION_TIME_SECONDS = 1800;
+const EXPORT_CONTENT_TYPE = 'application/fhir+ndjson';
 const EXPORT_RESULTS_BUCKET = process.env.EXPORT_RESULTS_BUCKET || ' ';
 const EXPORT_RESULTS_SIGNER_ROLE_ARN = process.env.EXPORT_RESULTS_SIGNER_ROLE_ARN || '';
 const EXPORT_STATE_MACHINE_ARN = process.env.EXPORT_STATE_MACHINE_ARN || '';
@@ -45,6 +46,7 @@ const signExportResults = async (keys: string[]): Promise<{ key: string; url: st
                 Bucket: EXPORT_RESULTS_BUCKET,
                 Key: key,
                 Expires: EXPIRATION_TIME_SECONDS,
+                ResponseContentType: EXPORT_CONTENT_TYPE,
             }),
         })),
     );


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/fhir-works-on-aws-deployment/issues/442

Description of changes: As per the FHIR spec the response header should be se to `application/fhir+ndjson`

https://hl7.org/fhir/uv/bulkdata/export/index.html#response---success-2

Tested locally after change we can see the correct type: 
![image](https://user-images.githubusercontent.com/5750407/133715426-a8140f51-5263-4db3-8db1-9b4898124a51.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.