### PR TITLE
feat: support custom bulk export results URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.1000.0",
     "aws-xray-sdk": "^3.3.3",
-    "fhir-works-on-aws-interface": "^11.1.0",
+    "fhir-works-on-aws-interface": "^11.2.0",
     "flat": "^5.0.2",
     "lodash": "^4.17.20",
     "mime-types": "^2.1.26",

--- a/src/bulkExport/bulkExport.ts
+++ b/src/bulkExport/bulkExport.ts
@@ -34,8 +34,8 @@ export const getBulkExportResults = async (
     const keys = await getFiles(prefix);
 
     const resultUrls: { requiresAccessToken: boolean; urls: string[] } = await bulkExportResultsUrlGenerator.getUrls({
-        bucket: EXPORT_RESULTS_BUCKET,
-        keys,
+        exportBucket: EXPORT_RESULTS_BUCKET,
+        s3Keys: keys,
     });
 
     return {

--- a/src/bulkExport/bulkExportResultsUrlGenerator.ts
+++ b/src/bulkExport/bulkExportResultsUrlGenerator.ts
@@ -5,5 +5,8 @@
  */
 
 export interface BulkExportResultsUrlGenerator {
-    getUrls(options: { bucket: string; keys: string[] }): Promise<{ requiresAccessToken: boolean; urls: string[] }>;
+    getUrls(options: {
+        exportBucket: string;
+        s3Keys: string[];
+    }): Promise<{ requiresAccessToken: boolean; urls: string[] }>;
 }

--- a/src/bulkExport/bulkExportResultsUrlGenerator.ts
+++ b/src/bulkExport/bulkExportResultsUrlGenerator.ts
@@ -1,0 +1,9 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+export interface BulkExportResultsUrlGenerator {
+    getUrls(options: { bucket: string; keys: string[] }): Promise<{ requiresAccessToken: boolean; urls: string[] }>;
+}

--- a/src/bulkExport/bulkExportS3PresignedUrlGenerator.ts
+++ b/src/bulkExport/bulkExportS3PresignedUrlGenerator.ts
@@ -1,0 +1,55 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { STS } from 'aws-sdk';
+import { BulkExportResultsUrlGenerator } from './bulkExportResultsUrlGenerator';
+import AWS from '../AWS';
+
+const EXPIRATION_TIME_SECONDS = 1800;
+const EXPORT_CONTENT_TYPE = 'application/fhir+ndjson';
+const EXPORT_RESULTS_SIGNER_ROLE_ARN = process.env.EXPORT_RESULTS_SIGNER_ROLE_ARN || '';
+
+export class BulkExportS3PresignedUrlGenerator implements BulkExportResultsUrlGenerator {
+    private readonly stsClient: STS;
+
+    constructor() {
+        this.stsClient = new AWS.STS();
+    }
+
+    async getUrls({ keys, bucket }: { bucket: string; keys: string[] }) {
+        const assumeRoleResponse = await this.stsClient
+            .assumeRole({
+                RoleArn: EXPORT_RESULTS_SIGNER_ROLE_ARN,
+                RoleSessionName: 'signBulkExportResults',
+                DurationSeconds: EXPIRATION_TIME_SECONDS,
+            })
+            .promise();
+
+        const s3 = new AWS.S3({
+            credentials: {
+                accessKeyId: assumeRoleResponse.Credentials!.AccessKeyId,
+                secretAccessKey: assumeRoleResponse.Credentials!.SecretAccessKey,
+                sessionToken: assumeRoleResponse.Credentials!.SessionToken,
+            },
+        });
+
+        const urls: string[] = await Promise.all(
+            keys.map(async (key) =>
+                s3.getSignedUrlPromise('getObject', {
+                    Bucket: bucket,
+                    Key: key,
+                    Expires: EXPIRATION_TIME_SECONDS,
+                    ResponseContentType: EXPORT_CONTENT_TYPE,
+                }),
+            ),
+        );
+
+        return {
+            requiresAccessToken: false,
+            urls,
+        };
+    }
+}

--- a/src/bulkExport/bulkExportS3PresignedUrlGenerator.ts
+++ b/src/bulkExport/bulkExportS3PresignedUrlGenerator.ts
@@ -19,7 +19,7 @@ export class BulkExportS3PresignedUrlGenerator implements BulkExportResultsUrlGe
         this.stsClient = new AWS.STS();
     }
 
-    async getUrls({ keys, bucket }: { bucket: string; keys: string[] }) {
+    async getUrls({ s3Keys, exportBucket }: { exportBucket: string; s3Keys: string[] }) {
         const assumeRoleResponse = await this.stsClient
             .assumeRole({
                 RoleArn: EXPORT_RESULTS_SIGNER_ROLE_ARN,
@@ -37,9 +37,9 @@ export class BulkExportS3PresignedUrlGenerator implements BulkExportResultsUrlGe
         });
 
         const urls: string[] = await Promise.all(
-            keys.map(async (key) =>
+            s3Keys.map(async (key) =>
                 s3.getSignedUrlPromise('getObject', {
-                    Bucket: bucket,
+                    Bucket: exportBucket,
                     Key: key,
                     Expires: EXPIRATION_TIME_SECONDS,
                     ResponseContentType: EXPORT_CONTENT_TYPE,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export { startExportJobHandler } from './bulkExport/startExportJob';
 export { stopExportJobHandler } from './bulkExport/stopExportJob';
 export { getJobStatusHandler } from './bulkExport/getJobStatus';
 export { updateStatusStatusHandler } from './bulkExport/updateStatus';
+export { BulkExportResultsUrlGenerator } from './bulkExport/bulkExportResultsUrlGenerator';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,10 +2245,10 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
-fhir-works-on-aws-interface@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.1.0.tgz#5950cb0538f831b6b2b34a0c83ab411c5a4e521c"
-  integrity sha512-wqLc3AFX8NwHQl5Ps406ozwz5LqXqKzXynicHbmsM8e29Hsb8tGS8+p2sXvhG9y+/DBj7QJljcJYN69F0eBt0g==
+fhir-works-on-aws-interface@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.2.0.tgz#2e12b3406ace4e24df8a18a827c50b834b633339"
+  integrity sha512-in2KVLKNfHPmJBwDNZrnJKg6VUrLncgBeL5Ow6ZE0tLxILBzZLNK7KWfcPlH3l6jQ4N9HLcF/GrOAGsGUGjHyQ==
   dependencies:
     winston "^3.3.3"
     winston-transport "^4.4.0"


### PR DESCRIPTION
Allows customers to provide an implementation of `bulkExportResultsUrlGenerator` on the `DynamoDbDataService` constructor to customize the location of bulk export results and the value of `requiresAccessToken` 

It is mostly a refactor. There are no functional changes with the default settings.

Related PRs (unit tests her fail until I publish and bump the interface version):
- https://github.com/awslabs/fhir-works-on-aws-interface/pull/85

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.