### PR TITLE
feat: pass jobOwnerId param to bulk export job

### DIFF
--- a/src/bulkExport/bulkExport.test.ts
+++ b/src/bulkExport/bulkExport.test.ts
@@ -93,6 +93,7 @@ describe('startJobExecution', () => {
     });
 
     const jobId = 'job-1';
+    const jobOwnerId = 'owner-1';
     const exportType = 'system';
     const transactionTime = '2020-10-10T00:00:00.000Z';
     const since = '2020-10-09T00:00:00.000Z';
@@ -107,7 +108,7 @@ describe('startJobExecution', () => {
         const job: BulkExportJob = {
             jobId,
             jobStatus: 'in-progress',
-            jobOwnerId: 'owner-1',
+            jobOwnerId,
             exportType,
             transactionTime,
             outputFormat,
@@ -116,6 +117,7 @@ describe('startJobExecution', () => {
 
         const expectedInput = {
             jobId,
+            jobOwnerId,
             exportType,
             transactionTime,
             since,
@@ -143,7 +145,7 @@ describe('startJobExecution', () => {
         const job: BulkExportJob = {
             jobId,
             jobStatus: 'in-progress',
-            jobOwnerId: 'owner-1',
+            jobOwnerId,
             exportType,
             transactionTime,
             outputFormat,
@@ -153,6 +155,7 @@ describe('startJobExecution', () => {
 
         const expectedInput = {
             jobId,
+            jobOwnerId,
             exportType,
             transactionTime,
             since,

--- a/src/bulkExport/bulkExport.ts
+++ b/src/bulkExport/bulkExport.ts
@@ -50,6 +50,7 @@ export const getBulkExportResults = async (
 export const startJobExecution = async (bulkExportJob: BulkExportJob): Promise<void> => {
     const {
         jobId,
+        jobOwnerId,
         exportType,
         groupId,
         type,
@@ -62,6 +63,7 @@ export const startJobExecution = async (bulkExportJob: BulkExportJob): Promise<v
     } = bulkExportJob;
     const params: any = {
         jobId,
+        jobOwnerId,
         exportType,
         transactionTime,
         since,

--- a/src/bulkExport/getJobStatus.test.ts
+++ b/src/bulkExport/getJobStatus.test.ts
@@ -14,6 +14,8 @@ import DynamoDbParamBuilder from '../dataServices/dynamoDbParamBuilder';
 
 AWSMock.setSDKInstance(AWS);
 
+const jobOwnerId = 'owner-1';
+
 describe('getJobStatus', () => {
     beforeEach(() => {
         process.env.GLUE_JOB_NAME = 'jobName';
@@ -23,6 +25,7 @@ describe('getJobStatus', () => {
     test('completed job', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -47,6 +50,7 @@ describe('getJobStatus', () => {
         });
         await expect(getJobStatusHandler(event, null as any, null as any)).resolves.toEqual({
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -60,6 +64,7 @@ describe('getJobStatus', () => {
     test('completed job in multi-tenancy mode', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             tenantId: 'tenant1',
             exportType: 'system',
             transactionTime: '',
@@ -87,6 +92,7 @@ describe('getJobStatus', () => {
         });
         await expect(getJobStatusHandler(event, null as any, null as any)).resolves.toEqual({
             jobId: '1',
+            jobOwnerId,
             tenantId: 'tenant1',
             exportType: 'system',
             transactionTime: '',
@@ -102,6 +108,7 @@ describe('getJobStatus', () => {
     test('failed job', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -125,6 +132,7 @@ describe('getJobStatus', () => {
         });
         await expect(getJobStatusHandler(event, null as any, null as any)).resolves.toEqual({
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -138,6 +146,7 @@ describe('getJobStatus', () => {
     test('canceled job', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -161,6 +170,7 @@ describe('getJobStatus', () => {
         });
         await expect(getJobStatusHandler(event, null as any, null as any)).resolves.toEqual({
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -175,6 +185,7 @@ describe('getJobStatus', () => {
         delete process.env.GLUE_JOB_NAME;
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -189,6 +200,7 @@ describe('getJobStatus', () => {
     test('missing glueJobRunId ', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
         };

--- a/src/bulkExport/startExportJob.test.ts
+++ b/src/bulkExport/startExportJob.test.ts
@@ -9,6 +9,8 @@ import { startExportJobHandler } from './startExportJob';
 
 AWSMock.setSDKInstance(AWS);
 
+const jobOwnerId = 'owner-1';
+
 describe('getJobStatus', () => {
     beforeEach(() => {
         process.env.GLUE_JOB_NAME = 'jobName';
@@ -18,6 +20,7 @@ describe('getJobStatus', () => {
     test('start job', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
         };
@@ -29,6 +32,7 @@ describe('getJobStatus', () => {
         });
         await expect(startExportJobHandler(event, null as any, null as any)).resolves.toEqual({
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -40,6 +44,7 @@ describe('getJobStatus', () => {
     test('start job in multi-tenancy mode', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             tenantId: 'tenant1',
             exportType: 'system',
             transactionTime: '',
@@ -52,6 +57,7 @@ describe('getJobStatus', () => {
         });
         await expect(startExportJobHandler(event, null as any, null as any)).resolves.toEqual({
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             tenantId: 'tenant1',
@@ -64,6 +70,7 @@ describe('getJobStatus', () => {
     test('glue exception', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
         };
@@ -78,6 +85,7 @@ describe('getJobStatus', () => {
         delete process.env.GLUE_JOB_NAME;
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
         };

--- a/src/bulkExport/startExportJob.ts
+++ b/src/bulkExport/startExportJob.ts
@@ -22,6 +22,7 @@ export const startExportJobHandler: Handler<
             JobName: GLUE_JOB_NAME,
             Arguments: {
                 '--jobId': event.jobId,
+                '--jobOwnerId': event.jobOwnerId,
                 '--exportType': event.exportType,
                 '--transactionTime': event.transactionTime,
                 '--groupId': event.groupId!,

--- a/src/bulkExport/stopExportJob.test.ts
+++ b/src/bulkExport/stopExportJob.test.ts
@@ -9,6 +9,8 @@ import { stopExportJobHandler } from './stopExportJob';
 
 AWSMock.setSDKInstance(AWS);
 
+const jobOwnerId = 'owner-1';
+
 describe('getJobStatus', () => {
     const glueJobName = 'jobName';
     const glueJobRunId = 'jr_1';
@@ -20,6 +22,7 @@ describe('getJobStatus', () => {
     test('stop job successfully', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -44,6 +47,7 @@ describe('getJobStatus', () => {
     test('stop job failed', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -75,6 +79,7 @@ describe('getJobStatus', () => {
         delete process.env.GLUE_JOB_NAME;
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {
@@ -89,6 +94,7 @@ describe('getJobStatus', () => {
     test('missing glueJobRunId ', async () => {
         const event: BulkExportStateMachineGlobalParameters = {
             jobId: '1',
+            jobOwnerId,
             exportType: 'system',
             transactionTime: '',
             executionParameters: {},

--- a/src/bulkExport/types.ts
+++ b/src/bulkExport/types.ts
@@ -20,6 +20,7 @@ export interface BulkExportStateMachineExecutionParameters {
  */
 export interface BulkExportStateMachineGlobalParameters {
     jobId: string;
+    jobOwnerId: string;
     exportType: ExportType;
     transactionTime: string;
     groupId?: string;

--- a/src/bulkExport/updateStatus.test.ts
+++ b/src/bulkExport/updateStatus.test.ts
@@ -13,9 +13,12 @@ import DynamoDbParamBuilder from '../dataServices/dynamoDbParamBuilder';
 
 AWSMock.setSDKInstance(AWS);
 
+const jobOwnerId = 'owner-1';
+
 describe('updateStatus', () => {
     const event: BulkExportStateMachineGlobalParameters = {
         jobId: '1',
+        jobOwnerId,
         exportType: 'system',
         transactionTime: '',
         executionParameters: {


### PR DESCRIPTION
`jobOwnerId` will be used by the glue job script to set it as metadata on the bulk export results s3 files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.