### PR TITLE
test: Update release-pr workflow to use PR_TOKEN instead of GITHUB_TOKEN so that PR checks are triggered

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,4 +37,4 @@ jobs:
           pr_draft: false
           pr_reviewer: "awslabs/aws-chamonix-fhir"
           pr_label: "auto-release-pr"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
Description of changes:
When a new PR is created by `release-pr` workflow, the PR checks are not initiated.

The solution is to use our own personal access token instead of `GITHUB_TOKEN`.

More [context](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token) here.

I tested this code in my forked repo and it worked as expected.

This is the [PR](https://github.com/nguyen102/fhir-works-on-aws-search-es/pull/3) that was automatically created. As you can see the GH status checks were automatically run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.