### PR TITLE
docs: Update README to specify that deployment package depends on this package, not vice versa

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ This package is dependent on:
 
 - [interface component](https://github.com/awslabs/fhir-works-on-aws-interface)
   - This package defines the interface we are trying to use
+
+Package that depends on `fhir-works-on-aws-persistence-ddb` package:
 - [deployment component](https://github.com/awslabs/fhir-works-on-aws-deployment)
-  - This package deploys this and all the default components
+  - This package deploys `fhir-works-on-aws-persistence-ddb` and all the other default components
 
 ## Known issues
 


### PR DESCRIPTION
docs: Update README to specify that deployment package depends on this package, not vice versa

Issue #, if available:
https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/issues/133

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.