### PR TITLE
fix: properly update subscriptionStatus on update or delete

### DIFF
--- a/src/dataServices/dynamoDbParamBuilder.ts
+++ b/src/dataServices/dynamoDbParamBuilder.ts
@@ -84,8 +84,6 @@ export default class DynamoDbParamBuilder {
             },
         };
         
-        console.log(params);
-        
         return params;
     }
 

--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -75,7 +75,7 @@ export class DynamoDbUtil {
         item[LOCK_END_TS_FIELD] = Date.now();
 
         const activeSubscription =
-            documentStatus === DOCUMENT_STATUS.AVAILABLE &&
+            documentStatus === (DOCUMENT_STATUS.AVAILABLE || DOCUMENT_STATUS.PENDING) &&
             resource.resourceType === 'Subscription' &&
             (resource.status === 'active' || resource.status === 'requested');
         if (activeSubscription) {


### PR DESCRIPTION
Issue #, if available:

Description of changes: Update param builders to handle updating _subscriptionStatus on Update/Delete operations on subscriptions.

**Testing**
- deployed successfully to an AWS account.
- posted a Subscription resource using Postman
- ran a query on getActiveSubscriptions to see which SubscriptionResources were returned and whether they were supposed to or not
- put an update on a subscription using Postman and made sure subscriptionStatus was correctly updated
- deleted a subscription and made sure that it did not show up when querying getActiveSubscriptions again.
- ----
- redeployed on a multi-tenant deployment
- ensured all operations on subscriptions ran as expected with the same method as above

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.