### PR TITLE
fix: update code coverage action to not run on feat branches

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -5,7 +5,13 @@
 
 name: Code Coverage Report
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - mainline
+  push:
+    branches:
+      - mainline
 
 jobs:
   report-test-coverage:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
updated codecov action to not run on PRs not targeting mainline (i.e. feat branches)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.