### PR TITLE
fix: update status correctly when posting in a bundle

### DIFF
--- a/src/dataServices/dynamoDbUtil.ts
+++ b/src/dataServices/dynamoDbUtil.ts
@@ -75,7 +75,7 @@ export class DynamoDbUtil {
         item[LOCK_END_TS_FIELD] = Date.now();
 
         const activeSubscription =
-            documentStatus === (DOCUMENT_STATUS.AVAILABLE || DOCUMENT_STATUS.PENDING) &&
+            (documentStatus === DOCUMENT_STATUS.AVAILABLE || documentStatus === DOCUMENT_STATUS.PENDING) &&
             resource.resourceType === 'Subscription' &&
             (resource.status === 'active' || resource.status === 'requested');
         if (activeSubscription) {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fixed a statement that was ignoring any subscriptions that were created as part of a bundle and not setting the status to active.
Tested by POSTing a bundle with subscriptions and retrieving those subscriptions to ensure that the `status` was correctly set to `active`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.