### PR TITLE
move custom fields in Binary Resource to _data extension

### DIFF
--- a/src/objectStorageService/s3DataService.test.ts
+++ b/src/objectStorageService/s3DataService.test.ts
@@ -68,7 +68,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'application/pdf',
-                presignedPutUrl: 'https://VALID_S3_PUT_URL.com/tenant1/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedPutUrl',
+                            valueString: 'https://VALID_S3_PUT_URL.com/tenant1/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -91,7 +98,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'application/pdf',
-                presignedGetUrl: 'https://VALID_S3_GET_URL.com/tenant1/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedGetUrl',
+                            valueString: 'https://VALID_S3_GET_URL.com/tenant1/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -120,7 +134,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'image/jpeg',
-                presignedPutUrl: 'https://VALID_S3_PUT_URL.com/tenant1/id_2.jpeg/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedPutUrl',
+                            valueString: 'https://VALID_S3_PUT_URL.com/tenant1/id_2.jpeg/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -189,7 +210,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'application/pdf',
-                presignedPutUrl: 'https://VALID_S3_PUT_URL.com/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedPutUrl',
+                            valueString: 'https://VALID_S3_PUT_URL.com/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -212,7 +240,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'application/pdf',
-                presignedGetUrl: 'https://VALID_S3_GET_URL.com/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedGetUrl',
+                            valueString: 'https://VALID_S3_GET_URL.com/id_1.pdf/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -240,7 +275,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'image/jpeg',
-                presignedPutUrl: 'https://VALID_S3_PUT_URL.com/id_2.jpeg/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedPutUrl',
+                            valueString: 'https://VALID_S3_PUT_URL.com/id_2.jpeg/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -306,7 +348,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'image/jpeg',
-                presignedPutUrl: 'https://VALID_S3_PUT_URL.com/id_1.jpeg/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedPutUrl',
+                            valueString: 'https://VALID_S3_PUT_URL.com/id_1.jpeg/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -334,7 +383,14 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources; vers
             resource: {
                 resourceType: 'Binary',
                 contentType: 'image/jpeg',
-                presignedPutUrl: 'https://VALID_S3_PUT_URL.com/id_2.jpeg/VALID_TEMP_CREDENTIAL',
+                _data: {
+                    extension: [
+                        {
+                            url: 'presignedPutUrl',
+                            valueString: 'https://VALID_S3_PUT_URL.com/id_2.jpeg/VALID_TEMP_CREDENTIAL',
+                        },
+                    ],
+                },
             },
         });
 

--- a/src/objectStorageService/s3DataService.ts
+++ b/src/objectStorageService/s3DataService.ts
@@ -90,7 +90,15 @@ export class S3DataService implements Persistence {
         }
 
         const updatedResource = { ...resource };
-        updatedResource.presignedPutUrl = presignedPutUrlResponse.message;
+        // eslint-disable-next-line no-underscore-dangle
+        updatedResource._data = {
+            extension: [
+                {
+                    url: 'presignedPutUrl',
+                    valueString: presignedPutUrlResponse.message,
+                },
+            ],
+        };
         return {
             success: true,
             message: 'Resource created',
@@ -120,7 +128,15 @@ export class S3DataService implements Persistence {
         }
 
         const updatedResource = { ...resource };
-        updatedResource.presignedPutUrl = presignedPutUrlResponse.message;
+        // eslint-disable-next-line no-underscore-dangle
+        updatedResource._data = {
+            extension: [
+                {
+                    url: 'presignedPutUrl',
+                    valueString: presignedPutUrlResponse.message,
+                },
+            ],
+        };
         return {
             success: true,
             message: 'Resource updated',
@@ -208,8 +224,15 @@ export class S3DataService implements Persistence {
 
         const binary = dbResponse.resource;
         // Add binary content to message
-        binary.presignedGetUrl = presignedGetUrlResponse.message;
-
+        // eslint-disable-next-line no-underscore-dangle
+        binary._data = {
+            extension: [
+                {
+                    url: 'presignedGetUrl',
+                    valueString: presignedGetUrlResponse.message,
+                },
+            ],
+        };
         return { message: 'Item found', resource: binary };
     }
 }


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/issues/149

Description of changes:
Move custom fields of Binary Resource to `_data.extension` to meet FHIR spec

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.